### PR TITLE
feat: add nix overlay that supports selecting either the latest go binary distribution or a specific version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,60 @@
 # go-overlay
 
-Pure and reproducible nix overlay of binary distributed golang toolchains.
+Pure and reproducible nix overlay of binary distributed golang toolchains. Current oldest supported toolchain is 1.17, the latest version is always auto-updated through GitHub Actions.
+
+## Installation
+
+### Nix Flakes
+
+Running `nix develop` will enter a shell with the latest version of Go installed.
+
+```nix
+{
+  description = "A Go-Overlay DevShell Example";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    go-overlay.url = "github:purpleclay/go-overlay";
+  };
+
+  outputs = { nixpkgs, go-overlay, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ go-overlay.overlays.default ];
+        };
+      in
+      {
+        devShells.default = with pkgs; mkShell {
+          buildInputs = [ go-bin.latest ];
+        };
+      }
+    );
+}
+```
+
+```sh
+$ nix develop
+$ go version
+
+# newest version at time of writing
+go version go1.25.5 linux/amd64
+```
+
+## Cheat Sheet
+
+- Always select the latest version of Go:
+
+```sh
+go-bin.latest
+```
+
+- Lock to a specific version of Go for pure reproducibility:
+
+```sh
+go-bin.versions."1.17.2"
+go-bin.versions."1.21.4"
+go-bin.versions."1.25.4"
+```

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,0 +1,19 @@
+# The main entry point for go-overlay, providing the go-bin attribute set with version selection
+{
+  lib,
+  pkgs,
+}: let
+  manifestsLib = import ./manifests.nix {inherit lib;};
+  mkGoToolchain = import ./mk-go-toolchain.nix {
+    inherit lib;
+    inherit (pkgs) stdenv fetchurl;
+  };
+
+  allVersions =
+    lib.mapAttrs
+    (version: manifest: mkGoToolchain manifest)
+    manifestsLib.manifests;
+in {
+  latest = allVersions.${manifestsLib.latest};
+  versions = allVersions;
+}

--- a/lib/manifests.nix
+++ b/lib/manifests.nix
@@ -1,0 +1,53 @@
+{lib}: let
+  # Load all manifest files from the manifests directory
+  manifestDir = ../manifests;
+  manifestFiles = builtins.readDir manifestDir;
+
+  # Filter to only .nix files and strip the extension to get version
+  nixFiles =
+    lib.filterAttrs
+    (name: type: type == "regular" && lib.hasSuffix ".nix" name)
+    manifestFiles;
+
+  # Load each manifest, keyed by version string (filename without .nix)
+  loadManifest = filename: import (manifestDir + "/${filename}");
+
+  # Create attribute set: { "1.21.6" = <manifest>; "1.25.5" = <manifest>; ... }
+  manifests =
+    lib.mapAttrs'
+    (filename: _: let
+      version = lib.removeSuffix ".nix" filename;
+    in
+      lib.nameValuePair version (loadManifest filename))
+    nixFiles;
+
+  # Parse version string into integer components (major, minor, patch) for comparison
+  parseVersion = v: let
+    parts = lib.splitString "." v;
+  in {
+    major = lib.toInt (builtins.elemAt parts 0);
+    minor = lib.toInt (builtins.elemAt parts 1);
+    patch =
+      if builtins.length parts > 2
+      then lib.toInt (builtins.elemAt parts 2)
+      else 0;
+  };
+
+  # Compare two version strings
+  compareVersions = a: b: let
+    va = parseVersion a;
+    vb = parseVersion b;
+  in
+    if va.major != vb.major
+    then va.major - vb.major
+    else if va.minor != vb.minor
+    then va.minor - vb.minor
+    else va.patch - vb.patch;
+
+  # To identify the latest available version we must sorted all versions
+  # in descending order and then take the first element
+  sortedVersions = lib.sort (a: b: compareVersions a b > 0) (builtins.attrNames manifests);
+  latest = builtins.head sortedVersions;
+in {
+  inherit manifests latest;
+}

--- a/lib/mk-go-toolchain.nix
+++ b/lib/mk-go-toolchain.nix
@@ -1,0 +1,42 @@
+# Builds a Go toolchain derivation from manifest data
+{
+  lib,
+  stdenv,
+  fetchurl,
+}: manifest: let
+  platform = manifest.${stdenv.hostPlatform.system} or null;
+in
+  if platform == null
+  then throw "go-overlay: Go ${manifest.version} is not available for ${stdenv.hostPlatform.system}"
+  else
+    stdenv.mkDerivation {
+      pname = "go";
+      version = manifest.version;
+
+      src = fetchurl {
+        url = platform.url;
+        sha256 = platform.sha256;
+      };
+
+      # Go binary distributions are pre-built and statically linked
+      dontBuild = true;
+      dontConfigure = true;
+      dontStrip = true;
+      dontPatchELF = true;
+      dontFixup = true;
+
+      installPhase = ''
+        runHook preInstall
+        mkdir -p $out
+        cp -r ./* $out/
+        runHook postInstall
+      '';
+
+      meta = {
+        description = "The Go programming language";
+        homepage = "https://go.dev/";
+        license = lib.licenses.bsd3;
+        maintainers = [];
+        platforms = builtins.attrNames (lib.filterAttrs (n: v: builtins.isAttrs v) manifest);
+      };
+    }


### PR DESCRIPTION
closes #7