### PR TITLE
fix: add CGO_ENABLED, GOOS, and GOARCH attributes to Go toolchain

### DIFF
--- a/lib/mk-go-toolchain.nix
+++ b/lib/mk-go-toolchain.nix
@@ -18,6 +18,13 @@ in
         sha256 = platform.sha256;
       };
 
+      # Expose GOOS, GOARCH, and CGO_ENABLED for compatibility with buildGoModule
+      inherit (stdenv.targetPlatform.go) GOOS GOARCH;
+      CGO_ENABLED =
+        if stdenv.targetPlatform.isWasi || (stdenv.targetPlatform.isPower64 && stdenv.targetPlatform.isBigEndian)
+        then 0
+        else 1;
+
       # Go binary distributions are pre-built and statically linked
       dontBuild = true;
       dontConfigure = true;


### PR DESCRIPTION
closes #38