### PR TITLE
fix: filter out modules with no imported packages from vendor manifest

### DIFF
--- a/govendor.nix
+++ b/govendor.nix
@@ -3,8 +3,8 @@
   go,
   commit ? "unknown",
 }: let
-  version = "v0.5.0";
-  buildDate = "2025-12-29T00:00:00Z";
+  version = "v0.5.1";
+  buildDate = "2026-01-01T00:00:00Z";
 in
   buildGoApplication {
     inherit version go;

--- a/internal/mod/gomod.go
+++ b/internal/mod/gomod.go
@@ -237,6 +237,11 @@ func (f *GoModFile) resolveModules(downloads []goModuleDownload, pkgsByMod map[s
 	p := pool.NewWithResults[GoModule]().WithErrors().WithMaxGoroutines(8)
 
 	for _, meta := range downloads {
+		// Only process modules that have packages actually imported by the project
+		if _, ok := pkgsByMod[meta.Path]; !ok {
+			continue
+		}
+
 		p.Go(func() (GoModule, error) {
 			h := sha256.New()
 			if err := nar.DumpPathFilter(h, meta.Dir, func(path string, _ nar.NodeType) bool {

--- a/internal/mod/gowork.go
+++ b/internal/mod/gowork.go
@@ -287,6 +287,11 @@ func (w *GoWorkFile) resolveModules(downloads []goModuleDownload, pkgsByMod map[
 	p := pool.NewWithResults[GoModule]().WithErrors().WithMaxGoroutines(8)
 
 	for _, meta := range downloads {
+		// Only process modules that have packages actually imported by the workspace
+		if _, ok := pkgsByMod[meta.Path]; !ok {
+			continue
+		}
+
 		p.Go(func() (GoModule, error) {
 			return resolveModuleFromDownload(meta, pkgsByMod)
 		})


### PR DESCRIPTION
closes #129