### PR TITLE
feat: reconstruct workspace from manifest when go.work is absent

### DIFF
--- a/govendor.nix
+++ b/govendor.nix
@@ -3,8 +3,8 @@
   go,
   commit ? "unknown",
 }: let
-  version = "v0.7.0";
-  buildDate = "2026-01-03T00:00:00Z";
+  version = "v0.8.0";
+  buildDate = "2026-01-09T00:00:00Z";
 in
   buildGoApplication {
     inherit version go;

--- a/internal/cli/govendor/root.go
+++ b/internal/cli/govendor/root.go
@@ -25,15 +25,13 @@ vendored dependencies without requiring nixpkgs' patched Go toolchain.
 
 Supports both single modules (go.mod) and workspaces (go.work). When a go.work
 file is detected, a unified manifest is generated containing dependencies from
-all workspace modules.`,
+all workspace modules. As go.work files are typically gitignored, the workspace
+is reconstructed from the manifest when go.work is not present.`,
 		Example: `  # Generate vendor manifest for current directory
   govendor
 
   # Generate vendor manifest for specific paths
   govendor ./api ./web
-
-  # Generate vendor manifest for a Go workspace (auto-detects go.work)
-  govendor ./my-workspace
 
   # Recursively scan for go.mod files, limiting depth to 2 directories
   govendor --recursive --depth 2


### PR DESCRIPTION
closes #145