### PR TITLE
fix: detect go workspace manifest drift from submodule paths

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 - 2025 Purple Clay
+Copyright (c) 2023 - 2026 Purple Clay
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -882,6 +882,13 @@ govendor.................................................................Failed
 
 Run `govendor` to regenerate the manifest, then commit both files together.
 
+> [!NOTE]
+> For workspace projects where `go.work` is gitignored, use `--workspace` in the hook entry. This traverses up from submodule `go.mod` files to find the workspace's `govendor.toml`:
+>
+> ```nix
+> entry = "${go-overlay.packages.${system}.govendor}/bin/govendor --check --workspace";
+> ```
+
 ## Private Modules
 
 go-overlay supports private Go modules through standard Go authentication mechanisms.

--- a/govendor.nix
+++ b/govendor.nix
@@ -3,8 +3,8 @@
   go,
   commit ? "unknown",
 }: let
-  version = "v0.8.0";
-  buildDate = "2026-01-16T00:00:00Z";
+  version = "v0.8.1";
+  buildDate = "2026-01-18T00:00:00Z";
 in
   buildGoApplication {
     inherit version go;

--- a/internal/mod/scanner_test.go
+++ b/internal/mod/scanner_test.go
@@ -1,0 +1,44 @@
+package mod
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindWorkspaceManifestReturnsEmptyIfNotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	subDir := filepath.Join(tmpDir, "cmd", "api")
+	require.NoError(t, os.MkdirAll(subDir, 0o755))
+
+	origDir, _ := os.Getwd()
+	require.NoError(t, os.Chdir(tmpDir))
+	defer os.Chdir(origDir)
+
+	result, err := FindWorkspaceManifest(filepath.Join("cmd", "api", "go.mod"))
+
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func TestFindWorkspaceManifestTraversesUp(t *testing.T) {
+	tmpDir := t.TempDir()
+	subDir := filepath.Join(tmpDir, "cmd", "api")
+	require.NoError(t, os.MkdirAll(subDir, 0o755))
+
+	manifestFile := filepath.Join(tmpDir, "govendor.toml")
+	require.NoError(t, os.WriteFile(manifestFile, []byte("test"), 0o644))
+
+	origDir, _ := os.Getwd()
+	require.NoError(t, os.Chdir(tmpDir))
+	defer os.Chdir(origDir)
+
+	result, err := FindWorkspaceManifest(filepath.Join("cmd", "api", "go.mod"))
+
+	require.NoError(t, err)
+	expected, _ := filepath.EvalSymlinks(manifestFile)
+	assert.Equal(t, expected, result)
+}


### PR DESCRIPTION
closes #155