### PR TITLE
fix: allow .DS_Store when calculating remote module hash

### DIFF
--- a/internal/mod/gomod.go
+++ b/internal/mod/gomod.go
@@ -262,9 +262,7 @@ func (f *GoModFile) resolveModules(downloads []goModuleDownload, pkgsByMod map[s
 	for _, meta := range downloads {
 		p.Go(func() (GoModule, error) {
 			h := sha256.New()
-			if err := nar.DumpPathFilter(h, meta.Dir, func(path string, _ nar.NodeType) bool {
-				return strings.ToLower(filepath.Base(path)) != ".ds_store"
-			}); err != nil {
+			if err := nar.DumpPath(h, meta.Dir); err != nil {
 				return GoModule{}, err
 			}
 


### PR DESCRIPTION
A module that commits `.DS_Store` to its repo cannot be used with go-overlay, because `govendor` gets a different module hash than `fetch.sh`.

See here for an example of such a module:
https://github.com/crate-crypto/go-ipa