### PR TITLE
fix(scrape): match release candidates when Href uses a minor version prefix

### DIFF
--- a/goscrape.nix
+++ b/goscrape.nix
@@ -3,8 +3,8 @@
   go,
   commit ? "unknown",
 }: let
-  version = "v0.1.1";
-  buildDate = "2026-01-16T00:00:00Z";
+  version = "v0.1.2";
+  buildDate = "2026-02-15T00:00:00Z";
 in
   buildGoApplication {
     inherit version go;

--- a/internal/cli/goscrape/list_test.go
+++ b/internal/cli/goscrape/list_test.go
@@ -33,6 +33,9 @@ func TestListVersionsWithPrefix1_25(t *testing.T) {
 		"1.25.5",
 		"1.25.6",
 		"1.25.7",
+		"1.25rc1",
+		"1.25rc2",
+		"1.25rc3",
 	}
 	assert.Equal(t, expected, versions)
 }

--- a/internal/scrape/parse.go
+++ b/internal/scrape/parse.go
@@ -42,7 +42,8 @@ func Href(version string) chomp.Combinator[string] {
 		}
 
 		hrefVersion := normalizedVersion
-		if !strings.Contains(normalizedVersion, "rc") && !strings.Contains(normalizedVersion, "beta") {
+		if !strings.Contains(normalizedVersion, "rc") && !strings.Contains(normalizedVersion, "beta") &&
+			strings.Count(normalizedVersion, ".") >= 2 {
 			hrefVersion = normalizedVersion + "."
 		}
 


### PR DESCRIPTION
closes #206