### PR TITLE
feat: Set meta.mainProgram in toolchain and tool packages

### DIFF
--- a/lib/mk-go-tool.nix
+++ b/lib/mk-go-tool.nix
@@ -99,5 +99,6 @@ in
       description = "${pname} - built from ${manifest.module}@v${manifest.version}";
       homepage = "https://pkg.go.dev/${manifest.module}";
       license = lib.licenses.bsd3;
+      mainProgram = pname;
     };
   }

--- a/lib/mk-go-toolchain.nix
+++ b/lib/mk-go-toolchain.nix
@@ -59,6 +59,7 @@
           license = lib.licenses.bsd3;
           maintainers = [];
           platforms = builtins.attrNames (lib.filterAttrs (n: v: builtins.isAttrs v) manifest);
+          mainProgram = "go";
         };
       };
 in


### PR DESCRIPTION
Hi 👋 

I'm using go-overlay to pin my go version and have earlier access to the latest release.
I regularly use `lib.getExe` in scripts to reference the go executable and other related executable.

When doing so with go-overlay I encountered warnings regarding a missing `meta.mainProgram` attribute:
<details><summary>Details</summary>
<pre>
                    evaluation warning: getExe: Package "go-1.26.0" does not have the meta.mainProgram attribute. We'll assume that the main program has the same name for now, but this behavior is deprecated, because it leads to surprising errors when the assumption does not hold. If the package has a main program, please set `meta.mainProgram` in its definition to make this warning go away. Otherwise, if the package does not have a main program, or if you don't control its definition, use getExe' to specify the name to the program, such as lib.getExe' foo "bar".
evaluation warning:
                    evaluation warning: getExe: Package "golangci-lint-2.9.0" does not have the meta.mainProgram attribute. We'll assume that the main program has the same name for now, but this behavior is deprecated, because it leads to surprising errors when the assumption does not hold. If the package has a main program, please set `meta.mainProgram` in its definition to make this warning go away. Otherwise, if the package does not have a main program, or if you don't control its definition, use getExe' to specify the name to the program, such as lib.getExe' foo "bar".
</pre>
</details>

To remedy this, I've added the mainProgram attribute to the mk-go-tool and mk-go-toolchain files, which has successfully removed the warning for me for `go` and `golangci-lint`.
I have not tested it with other tools.

Hope this helps. Kind regards,
yeldiR