### PR TITLE
fix(govendor): prevent false drift when using --include-platform

### DIFF
--- a/internal/mod/vendor.go
+++ b/internal/mod/vendor.go
@@ -195,8 +195,10 @@ func (v *Vendor) processWorkspaceManifest(goWork *GoWorkFile) vendorResult {
 			}
 		}
 
-		if !v.opts.force && existingHash == goWork.Hash() && len(v.opts.extraPlatforms) == 0 {
-			return resultOK(displayPath)
+		if !v.opts.force && existingHash == goWork.Hash() {
+			if v.opts.detectDrift || len(v.opts.extraPlatforms) == 0 {
+				return resultOK(displayPath)
+			}
 		}
 
 		if v.opts.detectDrift {
@@ -309,8 +311,10 @@ func (v *Vendor) processModFile(path string) vendorResult {
 			}
 		}
 
-		if !v.opts.force && existingHash == goMod.Hash() && len(v.opts.extraPlatforms) == 0 {
-			return resultOK(path)
+		if !v.opts.force && existingHash == goMod.Hash() {
+			if v.opts.detectDrift || len(v.opts.extraPlatforms) == 0 {
+				return resultOK(path)
+			}
 		}
 
 		if v.opts.detectDrift {


### PR DESCRIPTION
When running `govendor --check --include-platform linux/arm64`, the tool reports go.mod drift even when no changes have occurred and the go.mod hash matches the govendor.toml hash.

The platform-specific check path was incorrectly flagging drift despite identical SHA256 values. This change ensures that --include-platform respects the existing go.mod hash comparison logic and does not report drift when hashes match.

closes #237 