### PR TITLE
feat(govendor): validate schema version as part of drift detection

### DIFF
--- a/govendor.nix
+++ b/govendor.nix
@@ -3,8 +3,8 @@
   go,
   commit ? "unknown",
 }: let
-  version = "v0.9.2";
-  buildDate = "2026-02-15T00:00:00Z";
+  version = "v0.10.0";
+  buildDate = "2026-02-25T00:00:00Z";
 in
   buildGoApplication {
     inherit version go;

--- a/internal/mod/manifest.go
+++ b/internal/mod/manifest.go
@@ -103,6 +103,16 @@ func (m *VendorManifest) WriteTo(w io.Writer) (int64, error) {
 	return int64(n), nil
 }
 
+func extractSchema(data []byte) (int, error) {
+	var manifest struct {
+		Schema int `toml:"schema"`
+	}
+	if err := toml.Unmarshal(data, &manifest); err != nil {
+		return 0, err
+	}
+	return manifest.Schema, nil
+}
+
 func extractHash(data []byte) (string, error) {
 	var manifest struct {
 		Hash string `toml:"hash"`

--- a/internal/mod/manifest_test.go
+++ b/internal/mod/manifest_test.go
@@ -5,9 +5,33 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gotest.tools/v3/golden"
 )
+
+func TestExtractSchema(t *testing.T) {
+	t.Run("CurrentSchema", func(t *testing.T) {
+		data := []byte(`schema = 2`)
+		schema, err := extractSchema(data)
+		require.NoError(t, err)
+		assert.Equal(t, schemaVersion, schema)
+	})
+
+	t.Run("OldSchema", func(t *testing.T) {
+		data := []byte(`schema = 1`)
+		schema, err := extractSchema(data)
+		require.NoError(t, err)
+		assert.Equal(t, 1, schema)
+	})
+
+	t.Run("MissingSchema", func(t *testing.T) {
+		data := []byte(`hash = "sha256-abc123"`)
+		schema, err := extractSchema(data)
+		require.NoError(t, err)
+		assert.Equal(t, 0, schema)
+	})
+}
 
 func TestManifestWriteTo(t *testing.T) {
 	tests := []struct {

--- a/internal/mod/result.go
+++ b/internal/mod/result.go
@@ -85,6 +85,11 @@ func resultDrift(path, currentHash, manifestHash string) vendorResult {
 	return vendorResult{path: path, status: statusDrift, message: msg}
 }
 
+func resultSchemaMismatch(path string, manifestSchema, currentSchema int) vendorResult {
+	msg := fmt.Sprintf("govendor.toml uses schema v%d, current govendor requires schema v%d — run 'govendor' to regenerate", manifestSchema, currentSchema)
+	return vendorResult{path: path, status: statusDrift, message: msg}
+}
+
 func resultMissing(path string) vendorResult {
 	return vendorResult{path: path, status: statusMissing, message: "govendor.toml not found, run govendor to generate"}
 }

--- a/internal/mod/table_test.go
+++ b/internal/mod/table_test.go
@@ -21,6 +21,7 @@ func TestRenderResultsTableForGoMod(t *testing.T) {
 		resultMissing("path/to/missing/go.mod"),
 		resultNotFound("path/to/notfound/go.mod"),
 		resultOK("path/to/ok/go.mod"),
+		resultSchemaMismatch("path/to/schema-mismatch/go.mod", 1, 2),
 		resultSkipped("path/to/skipped/go.mod"),
 	}
 
@@ -36,6 +37,7 @@ func TestRenderResultsTableForGoWork(t *testing.T) {
 		resultMissing("path/to/missing/go.work"),
 		resultNotFound("path/to/notfound/go.work"),
 		resultOK("path/to/ok/go.work"),
+		resultSchemaMismatch("path/to/schema-mismatch/go.work", 1, 2),
 		resultSkipped("path/to/skipped/go.work"),
 	}
 

--- a/internal/mod/testdata/table_gomod.golden
+++ b/internal/mod/testdata/table_gomod.golden
@@ -1,21 +1,23 @@
-╭──────────────────────────┬─────────────┬───────────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ File                     │ Status      │ Message                                                                                               │
-├──────────────────────────┼─────────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│ path/to/drift/go.mod     │ ✗ drift     │ go.mod has changed, run 'govendor' to regenerate                                                      │
-│                          │             │                                                                                                       │
-│                          │             │   go.mod:        sha256-A3tDBEG/zwPthZ+l5TxH8XpVY9FRw/iEQOtMryi9zXg=                                  │
-│                          │             │   govendor.toml: sha256-juCtIr7pvECB2svxXEKFvbdj/vqWUbu5EECe2te0RTI=                                  │
-│ path/to/error/go.mod     │ ✗ error     │ go: github.com/nonexistent/fakerepo@v1.0.0: reading github.com/nonexistent/fakerepo/go.mod            │
-│                          │             │ at revision v1.0.0: git ls-remote -q origin in                                                        │
-│                          │             │ /Users/pthomas/go/pkg/mod/cache/vcs/52aff0ea21d8bd6eb4886c147731870e3188d46b62f672149e0462ee0612afe1: │
-│                          │             │ exit status 128:                                                                                      │
-│                          │             │     fatal: could not read Username for 'https://github.com': terminal prompts disabled                │
-│                          │             │ Confirm the import path was entered correctly.                                                        │
-│                          │             │ If this is a private repository, see https://golang.org/doc/faq#git_https for additional              │
-│                          │             │ information.                                                                                          │
-│ path/to/generated/go.mod │ ✓ generated │ generated govendor.toml with 10 dependencies                                                          │
-│ path/to/missing/go.mod   │ ✗ missing   │ govendor.toml not found, run govendor to generate                                                     │
-│ path/to/notfound/go.mod  │ ✗ error     │ go.mod does not exist, check path                                                                     │
-│ path/to/ok/go.mod        │ ✓ ok        │ govendor.toml is up to date                                                                           │
-│ path/to/skipped/go.mod   │ ○ skipped   │ go.mod has no external dependencies                                                                   │
-╰──────────────────────────┴─────────────┴───────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭────────────────────────────────┬─────────────┬───────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ File                           │ Status      │ Message                                                                                               │
+├────────────────────────────────┼─────────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────┤
+│ path/to/drift/go.mod           │ ✗ drift     │ go.mod has changed, run 'govendor' to regenerate                                                      │
+│                                │             │                                                                                                       │
+│                                │             │   go.mod:        sha256-A3tDBEG/zwPthZ+l5TxH8XpVY9FRw/iEQOtMryi9zXg=                                  │
+│                                │             │   govendor.toml: sha256-juCtIr7pvECB2svxXEKFvbdj/vqWUbu5EECe2te0RTI=                                  │
+│ path/to/error/go.mod           │ ✗ error     │ go: github.com/nonexistent/fakerepo@v1.0.0: reading github.com/nonexistent/fakerepo/go.mod            │
+│                                │             │ at revision v1.0.0: git ls-remote -q origin in                                                        │
+│                                │             │ /Users/pthomas/go/pkg/mod/cache/vcs/52aff0ea21d8bd6eb4886c147731870e3188d46b62f672149e0462ee0612afe1: │
+│                                │             │ exit status 128:                                                                                      │
+│                                │             │     fatal: could not read Username for 'https://github.com': terminal prompts disabled                │
+│                                │             │ Confirm the import path was entered correctly.                                                        │
+│                                │             │ If this is a private repository, see https://golang.org/doc/faq#git_https for additional              │
+│                                │             │ information.                                                                                          │
+│ path/to/generated/go.mod       │ ✓ generated │ generated govendor.toml with 10 dependencies                                                          │
+│ path/to/missing/go.mod         │ ✗ missing   │ govendor.toml not found, run govendor to generate                                                     │
+│ path/to/notfound/go.mod        │ ✗ error     │ go.mod does not exist, check path                                                                     │
+│ path/to/ok/go.mod              │ ✓ ok        │ govendor.toml is up to date                                                                           │
+│ path/to/schema-mismatch/go.mod │ ✗ drift     │ govendor.toml uses schema v1, current govendor requires schema v2 — run 'govendor' to                 │
+│                                │             │ regenerate                                                                                            │
+│ path/to/skipped/go.mod         │ ○ skipped   │ go.mod has no external dependencies                                                                   │
+╰────────────────────────────────┴─────────────┴───────────────────────────────────────────────────────────────────────────────────────────────────────╯

--- a/internal/mod/testdata/table_gowork.golden
+++ b/internal/mod/testdata/table_gowork.golden
@@ -1,21 +1,23 @@
-╭───────────────────────────┬─────────────┬───────────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ File                      │ Status      │ Message                                                                                               │
-├───────────────────────────┼─────────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│ path/to/drift/go.work     │ ✗ drift     │ go.work has changed, run 'govendor' to regenerate                                                     │
-│                           │             │                                                                                                       │
-│                           │             │   go.work:       sha256-A3tDBEG/zwPthZ+l5TxH8XpVY9FRw/iEQOtMryi9zXg=                                  │
-│                           │             │   govendor.toml: sha256-juCtIr7pvECB2svxXEKFvbdj/vqWUbu5EECe2te0RTI=                                  │
-│ path/to/error/go.work     │ ✗ error     │ go: github.com/nonexistent/fakerepo@v1.0.0: reading github.com/nonexistent/fakerepo/go.mod            │
-│                           │             │ at revision v1.0.0: git ls-remote -q origin in                                                        │
-│                           │             │ /Users/pthomas/go/pkg/mod/cache/vcs/52aff0ea21d8bd6eb4886c147731870e3188d46b62f672149e0462ee0612afe1: │
-│                           │             │ exit status 128:                                                                                      │
-│                           │             │     fatal: could not read Username for 'https://github.com': terminal prompts disabled                │
-│                           │             │ Confirm the import path was entered correctly.                                                        │
-│                           │             │ If this is a private repository, see https://golang.org/doc/faq#git_https for additional              │
-│                           │             │ information.                                                                                          │
-│ path/to/generated/go.work │ ✓ generated │ generated govendor.toml with 10 dependencies                                                          │
-│ path/to/missing/go.work   │ ✗ missing   │ govendor.toml not found, run govendor to generate                                                     │
-│ path/to/notfound/go.work  │ ✗ error     │ go.work does not exist, check path                                                                    │
-│ path/to/ok/go.work        │ ✓ ok        │ govendor.toml is up to date                                                                           │
-│ path/to/skipped/go.work   │ ○ skipped   │ go.work has no external dependencies                                                                  │
-╰───────────────────────────┴─────────────┴───────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─────────────────────────────────┬─────────────┬───────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ File                            │ Status      │ Message                                                                                               │
+├─────────────────────────────────┼─────────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────┤
+│ path/to/drift/go.work           │ ✗ drift     │ go.work has changed, run 'govendor' to regenerate                                                     │
+│                                 │             │                                                                                                       │
+│                                 │             │   go.work:       sha256-A3tDBEG/zwPthZ+l5TxH8XpVY9FRw/iEQOtMryi9zXg=                                  │
+│                                 │             │   govendor.toml: sha256-juCtIr7pvECB2svxXEKFvbdj/vqWUbu5EECe2te0RTI=                                  │
+│ path/to/error/go.work           │ ✗ error     │ go: github.com/nonexistent/fakerepo@v1.0.0: reading github.com/nonexistent/fakerepo/go.mod            │
+│                                 │             │ at revision v1.0.0: git ls-remote -q origin in                                                        │
+│                                 │             │ /Users/pthomas/go/pkg/mod/cache/vcs/52aff0ea21d8bd6eb4886c147731870e3188d46b62f672149e0462ee0612afe1: │
+│                                 │             │ exit status 128:                                                                                      │
+│                                 │             │     fatal: could not read Username for 'https://github.com': terminal prompts disabled                │
+│                                 │             │ Confirm the import path was entered correctly.                                                        │
+│                                 │             │ If this is a private repository, see https://golang.org/doc/faq#git_https for additional              │
+│                                 │             │ information.                                                                                          │
+│ path/to/generated/go.work       │ ✓ generated │ generated govendor.toml with 10 dependencies                                                          │
+│ path/to/missing/go.work         │ ✗ missing   │ govendor.toml not found, run govendor to generate                                                     │
+│ path/to/notfound/go.work        │ ✗ error     │ go.work does not exist, check path                                                                    │
+│ path/to/ok/go.work              │ ✓ ok        │ govendor.toml is up to date                                                                           │
+│ path/to/schema-mismatch/go.work │ ✗ drift     │ govendor.toml uses schema v1, current govendor requires schema v2 — run 'govendor' to                 │
+│                                 │             │ regenerate                                                                                            │
+│ path/to/skipped/go.work         │ ○ skipped   │ go.work has no external dependencies                                                                  │
+╰─────────────────────────────────┴─────────────┴───────────────────────────────────────────────────────────────────────────────────────────────────────╯

--- a/internal/mod/vendor.go
+++ b/internal/mod/vendor.go
@@ -184,6 +184,14 @@ func (v *Vendor) processWorkspaceManifest(goWork *GoWorkFile) vendorResult {
 	} else if err != nil {
 		return resultError(displayPath, err)
 	} else {
+		manifestSchema, err := extractSchema(existingData)
+		if err != nil {
+			return resultError(displayPath, err)
+		}
+		if manifestSchema != schemaVersion {
+			return resultSchemaMismatch(displayPath, manifestSchema, schemaVersion)
+		}
+
 		existingHash, err := extractHash(existingData)
 		if err != nil {
 			return resultError(displayPath, err)
@@ -301,6 +309,14 @@ func (v *Vendor) processModFile(path string) vendorResult {
 	} else if err != nil {
 		return resultError(path, err)
 	} else {
+		manifestSchema, err := extractSchema(existingData)
+		if err != nil {
+			return resultError(path, err)
+		}
+		if manifestSchema != schemaVersion {
+			return resultSchemaMismatch(path, manifestSchema, schemaVersion)
+		}
+
 		existingHash, err := extractHash(existingData)
 		if err != nil {
 			return resultError(path, err)


### PR DESCRIPTION
Closes #187

The `schema` field in `govendor.toml` is now validated before any hash comparison takes place. A mismatch between the manifest schema and the current schema version is reported as drift, prompting regeneration before hash comparisons that could produce misleading results.