### PR TITLE
fix(govendor): overwrite stale manifest when clearing dependencies

### DIFF
--- a/internal/mod/vendor.go
+++ b/internal/mod/vendor.go
@@ -285,16 +285,15 @@ func (v *Vendor) processModFile(path string) vendorResult {
 		return resultError(path, err)
 	}
 
-	if !goMod.HasDependencies() {
-		return resultSkipped(path)
-	}
-
 	vendorPath := filepath.Join(goMod.Dir(), vendorFile)
 	existingData, err := os.ReadFile(vendorPath)
 
 	extraPlatforms := v.opts.extraPlatforms
 
 	if os.IsNotExist(err) {
+		if !goMod.HasDependencies() {
+			return resultSkipped(path)
+		}
 		if v.opts.detectDrift {
 			return resultMissing(path)
 		}


### PR DESCRIPTION
Closes #276

When a `go.mod` that previously had external dependencies (and thus a generated `govendor.toml`) has all its dependencies removed and `go mod tidy` is run, the previous behavior returned `skipped` early and left the stale manifest behind with its outdated dependencies and hash.

Now it when the manifest gets updated with the latest `go.mod` hash with
no dependencies, an empty `[mod]` list is produced.