### PR TITLE
feat(builder): surface configurePhase build decisions in log output

### DIFF
--- a/builder/default.nix
+++ b/builder/default.nix
@@ -674,6 +674,8 @@
                 export GOPATH="$TMPDIR/go"
                 export GOPROXY=off
 
+                echo "go-overlay: using committed vendor/ directory"
+
                 # Use in-tree vendor directory as-is (from 'go work vendor')
                 chmod -R u+w vendor
 
@@ -689,7 +691,10 @@
 
                 # Generate go.work if not present in source
                 if [ ! -f go.work ]; then
+                  echo "go-overlay: generating go.work from govendor.toml"
                   printf '%s' ${escapeShellArg goWorkContent} > go.work
+                else
+                  echo "go-overlay: using go.work from source tree"
                 fi
 
                 # Copy vendor environment with external deps

--- a/examples/go-workspace-inferred/README.md
+++ b/examples/go-workspace-inferred/README.md
@@ -33,3 +33,9 @@ pkgs.buildGoWorkspace {
 ```
 
 `lib.cleanSourceWith` filters the source tree before it enters the Nix sandbox. Removing `go.work` causes `buildGoWorkspace` to generate one from the `[workspace]` section of `govendor.toml`. Use this pattern for projects that deliberately don't commit `go.work` — the manifest carries the workspace metadata so Nix builds remain reproducible.
+
+During the build, `buildGoWorkspace` logs which path was taken:
+
+```shell
+go-overlay: generating go.work from govendor.toml
+```

--- a/examples/go-workspace-vendored/README.md
+++ b/examples/go-workspace-vendored/README.md
@@ -27,3 +27,9 @@ pkgs.buildGoWorkspace {
 ```
 
 The `vendor/` directory is generated with `go work vendor` rather than `go mod vendor`, and is committed alongside the source. When no `modules` parameter is provided, `buildGoWorkspace` detects the vendor directory automatically and uses it in place of a `govendor.toml` manifest.
+
+During the build, `buildGoWorkspace` logs which path was taken:
+
+```shell
+go-overlay: using committed vendor/ directory
+```


### PR DESCRIPTION
closes #358

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Build now emits clear status messages showing when a committed vendor directory is used and when a workspace file is generated or preserved.

* **Documentation**
  * Updated docs and examples to show the new log messages and clarify automatic detection/use of vendor directories and workspace file generation during builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->