### PR TITLE
fix(builder)!: add explicit private module params to builder chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,10 @@ in {
 
 ## Private Go Modules
 
-Pass a `.netrc` file into the build sandbox for authentication:
+Private modules require two things: bypassing the public proxy, and credentials to authenticate with the private host. Set `GOPRIVATE` to route around the proxy and `netrcFile` to provide credentials:
+
+> [!TIP]
+> `GOPRIVATE` implicitly sets `GONOPROXY` and `GONOSUMDB` — you only need to set all three explicitly if you require different values for each.
 
 ```nix
 { pkgs, go }:
@@ -207,19 +210,19 @@ pkgs.buildGoApplication {
   src = ./.;
   modules = ./govendor.toml;
   netrcFile = "${builtins.getEnv "HOME"}/.netrc";
+  GOPRIVATE = "<your-private-host>/*";
 }
 ```
 
 > [!NOTE]
-> `builtins.getEnv` reads from the host environment, outside the Nix sandbox, so it requires `--impure`. This approach uses your shared `~/.netrc` file — credentials are not stored in the repo. If you prefer to keep a `.netrc` inside the source root, consider encrypting it with [git-crypt](https://github.com/AGWA/git-crypt) or [sops-nix](https://github.com/Mic92/sops-nix).
+> `builtins.getEnv "HOME"` reads the host environment to locate `~/.netrc` — this is why `--impure` is required. The file contents are read at eval time and passed into the build sandbox. Credentials are not stored in the repo. If you prefer to keep a `.netrc` inside the source root, consider encrypting it with [git-crypt](https://github.com/AGWA/git-crypt) or [sops-nix](https://github.com/Mic92/sops-nix).
 
 ```bash
-export GOPRIVATE="github.com/myorg/*"
 nix build --impure
 ```
 
 > [!CAUTION]
-> The `.netrc` file is copied into the Nix store, which is world-readable by default.
+> The `.netrc` contents are embedded in the derivation, which is stored in the Nix store. The Nix store is world-readable by default.
 
 ## Further Reading
 

--- a/builder/default.nix
+++ b/builder/default.nix
@@ -27,6 +27,7 @@
     concatMapStringsSep
     concatStringsSep
     escapeShellArg
+    optionalAttrs
     optionalString
     pathExists
     ;
@@ -42,29 +43,33 @@
     hash, # NAR hash from govendor.toml
     go,
     netrcFile ? null, # Path to a .netrc file for private module authentication
+    GOPRIVATE ? "", # Comma-separated list of module path prefixes to bypass proxy and checksum DB
+    GONOSUMDB ? "", # Comma-separated list of module path prefixes to bypass checksum DB
+    GONOPROXY ? "", # Comma-separated list of module path prefixes to bypass proxy
   }:
-    stdenvNoCC.mkDerivation {
-      name = "${baseNameOf goPackagePath}_${version}";
-      builder = ./fetch.sh;
-      inherit goPackagePath version;
-      netrcFile = optionalString (netrcFile != null) netrcFile;
-      nativeBuildInputs = [
-        cacert
-        git
-        go
-        jq
-      ];
-      outputHashMode = "recursive";
-      outputHashAlgo = null;
-      outputHash = hash;
-      impureEnvVars = [
-        "GOPROXY"
-        "GOPRIVATE"
-        "GONOPROXY"
-        "http_proxy"
-        "https_proxy"
-      ];
-    };
+    stdenvNoCC.mkDerivation (
+      {
+        name = "${baseNameOf goPackagePath}_${version}";
+        builder = ./fetch.sh;
+        inherit goPackagePath version;
+        nativeBuildInputs = [
+          cacert
+          git
+          go
+          jq
+        ];
+        outputHashMode = "recursive";
+        outputHashAlgo = null;
+        outputHash = hash;
+        impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ ["GOPROXY"];
+      }
+      // optionalAttrs (GOPRIVATE != "") {inherit GOPRIVATE;}
+      // optionalAttrs (GONOSUMDB != "") {inherit GONOSUMDB;}
+      // optionalAttrs (GONOPROXY != "") {inherit GONOPROXY;}
+      // optionalAttrs (netrcFile != null) {
+        NETRC_CONTENT = readFile netrcFile;
+      }
+    );
 
   # Generate modules.txt entry for a single module
   mkModuleEntry = goPackagePath: meta: let
@@ -136,6 +141,9 @@
     src ? null, # Source tree for local module replacements
     localReplaces ? {}, # Map of module path to Nix path for external local replaces
     netrcFile ? null, # Path to a .netrc file for private module authentication
+    GOPRIVATE ? "", # Comma-separated list of module path prefixes to bypass proxy and checksum DB
+    GONOSUMDB ? "", # Comma-separated list of module path prefixes to bypass checksum DB
+    GONOPROXY ? "", # Comma-separated list of module path prefixes to bypass proxy
   }: let
     useSymlinks = lib.versionAtLeast go.version "1.25";
     modules = manifest.mod or {};
@@ -156,7 +164,7 @@
               if (meta ? replaced) && meta.replaced != goPackagePath
               then meta.replaced
               else goPackagePath;
-            inherit go netrcFile;
+            inherit go netrcFile GOPRIVATE GONOSUMDB GONOPROXY;
             inherit (meta) version hash;
           }
       )
@@ -266,6 +274,9 @@
     allowGoReference ? false, # When true, disables -trimpath, -buildid= and disallowedReferences
     localReplaces ? {}, # Map of module path to Nix path for external local replaces
     netrcFile ? null, # Path to a .netrc file for private module authentication
+    GOPRIVATE ? "", # Comma-separated list of module path prefixes to bypass proxy and checksum DB
+    GONOSUMDB ? "", # Comma-separated list of module path prefixes to bypass checksum DB
+    GONOPROXY ? "", # Comma-separated list of module path prefixes to bypass proxy
     checkFlags ? [], # Additional flags passed to go test
     excludedPackages ? [], # Packages to exclude from testing
     CGO_ENABLED ? go.CGO_ENABLED,
@@ -310,7 +321,7 @@
       if useManifest
       then
         mkVendorEnv {
-          inherit go manifest src localReplaces netrcFile;
+          inherit go manifest src localReplaces netrcFile GOPRIVATE GONOSUMDB GONOPROXY;
         }
       else null;
   in
@@ -330,7 +341,7 @@
         Alternatively, commit a vendor directory using 'go mod vendor'.
     '';
       stdenv.mkDerivation (
-        builtins.removeAttrs attrs ["modules" "subPackages" "ldflags" "tags" "GOOS" "GOARCH" "CGO_ENABLED" "localReplaces" "netrcFile" "allowGoReference" "checkFlags" "excludedPackages"]
+        builtins.removeAttrs attrs ["modules" "subPackages" "ldflags" "tags" "GOOS" "GOARCH" "CGO_ENABLED" "localReplaces" "netrcFile" "GOPRIVATE" "GONOSUMDB" "GONOPROXY" "allowGoReference" "checkFlags" "excludedPackages"]
         // {
           inherit pname version src;
 
@@ -492,6 +503,9 @@
     tags ? [],
     allowGoReference ? false, # When true, disables -trimpath, -buildid= and disallowedReferences
     netrcFile ? null, # Path to a .netrc file for private module authentication
+    GOPRIVATE ? "", # Comma-separated list of module path prefixes to bypass proxy and checksum DB
+    GONOSUMDB ? "", # Comma-separated list of module path prefixes to bypass checksum DB
+    GONOPROXY ? "", # Comma-separated list of module path prefixes to bypass proxy
     checkFlags ? [], # Additional flags passed to go test
     excludedPackages ? [], # Packages to exclude from testing
     CGO_ENABLED ? go.CGO_ENABLED,
@@ -563,7 +577,7 @@
       mapAttrs (
         goPackagePath: meta:
           fetchGoModule {
-            inherit goPackagePath go netrcFile;
+            inherit goPackagePath go netrcFile GOPRIVATE GONOSUMDB GONOPROXY;
             inherit (meta) version hash;
           }
       )
@@ -641,7 +655,7 @@
         Alternatively, commit a vendor directory using 'go work vendor'.
     '';
       stdenv.mkDerivation (
-        builtins.removeAttrs attrs ["modules" "subPackages" "ldflags" "tags" "GOOS" "GOARCH" "CGO_ENABLED" "netrcFile" "allowGoReference" "checkFlags" "excludedPackages"]
+        builtins.removeAttrs attrs ["modules" "subPackages" "ldflags" "tags" "GOOS" "GOARCH" "CGO_ENABLED" "netrcFile" "GOPRIVATE" "GONOSUMDB" "GONOPROXY" "allowGoReference" "checkFlags" "excludedPackages"]
         // {
           inherit pname version src;
 

--- a/builder/fetch.sh
+++ b/builder/fetch.sh
@@ -5,16 +5,13 @@ export HOME=$(mktemp -d)
 export GOPATH="$HOME/go"
 export GOCACHE="$HOME/go-cache"
 
-# If a netrc file was provided, copy it into $HOME/.netrc for authentication.
+# If netrc credentials were provided, write them into $HOME/.netrc for authentication.
 # Both Go's HTTP client and git (via libcurl) read ~/.netrc for credentials
 # when accessing private module hosts.
-if [ -n "${netrcFile:-}" ]; then
-  if [ -f "$netrcFile" ]; then
-    cp "$netrcFile" "$HOME/.netrc"
-    echo "go-overlay: netrc credentials loaded from $netrcFile"
-  else
-    echo "go-overlay: warning: netrcFile was set but '$netrcFile' is missing or not a regular file — proceeding without credentials" >&2
-  fi
+if [ -n "${NETRC_CONTENT:-}" ]; then
+  printf '%s' "$NETRC_CONTENT" > "$HOME/.netrc"
+  chmod 600 "$HOME/.netrc"
+  echo "go-overlay: netrc credentials loaded"
 fi
 
 # Download the module and get the directory path from JSON output.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -119,6 +119,9 @@ Build a single-module Go application using vendored dependencies.
 | `allowGoReference` | `false`             | Allow Go toolchain in runtime closure                      |
 | `localReplaces`    | `{}`                | Map of module path to Nix path for external local replaces |
 | `netrcFile`        | `null`              | Path to a `.netrc` file for private module authentication  |
+| `GOPRIVATE`        | `""`                | Module path prefixes to bypass the proxy and checksum DB   |
+| `GONOSUMDB`        | `""`                | Module path prefixes to bypass the checksum DB only        |
+| `GONOPROXY`        | `""`                | Module path prefixes to bypass the proxy only              |
 | `doCheck`          | `false`             | Run tests during the build                                 |
 | `checkFlags`       | `[]`                | Additional flags passed to `go test`                       |
 | `excludedPackages` | `[]`                | Packages to exclude from testing                           |
@@ -142,6 +145,9 @@ Build applications from a Go workspace (`go.work`).
 | `tags`             | `[]`                | Build tags                                                 |
 | `allowGoReference` | `false`             | Allow Go toolchain in runtime closure                      |
 | `netrcFile`        | `null`              | Path to a `.netrc` file for private module authentication  |
+| `GOPRIVATE`        | `""`                | Module path prefixes to bypass the proxy and checksum DB   |
+| `GONOSUMDB`        | `""`                | Module path prefixes to bypass the checksum DB only        |
+| `GONOPROXY`        | `""`                | Module path prefixes to bypass the proxy only              |
 | `doCheck`          | `false`             | Run tests during the build                                 |
 | `checkFlags`       | `[]`                | Additional flags passed to `go test`                       |
 | `excludedPackages` | `[]`                | Packages to exclude from testing                           |
@@ -160,6 +166,9 @@ Create a vendor directory with `modules.txt` from a parsed `govendor.toml` manif
 | `src`           | `null`   | Source tree (required if manifest has local modules)       |
 | `localReplaces` | `{}`     | Map of module path to Nix path for external local replaces |
 | `netrcFile`     | `null`   | Path to a `.netrc` file for private module authentication  |
+| `GOPRIVATE`     | `""`     | Module path prefixes to bypass the proxy and checksum DB   |
+| `GONOSUMDB`     | `""`     | Module path prefixes to bypass the checksum DB only        |
+| `GONOPROXY`     | `""`     | Module path prefixes to bypass the proxy only              |
 
 ## Cross-Compilation
 


### PR DESCRIPTION
closes #370

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified private Go modules setup with a "Routing around the proxy" section, added guidance on GOPRIVATE/GONOPROXY/GONOSUMDB behavior and when impure mode is required.

* **New Features**
  * Exposed GOPRIVATE, GONOSUMDB and GONOPROXY as configurable options for Go module builds.

* **Chores**
  * Switched credential handling to accept embedded netrc content for builds, ensuring credentials are loaded into the build environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->