### PR TITLE
fix(builder): derive workspace test targets from go.work modules

### DIFF
--- a/builder/default.nix
+++ b/builder/default.nix
@@ -763,12 +763,17 @@
           doCheck = attrs.doCheck or false;
 
           checkPhase = let
+            # In workspace mode, go test ./... does not expand across module boundaries.
+            # Instead, derive test targets from the workspace modules listed in go.work.
+            # Falls back to subPackages if no workspace config is present (in-tree vendor mode).
+            workspaceTestTargets =
+              if workspaceConfig != null
+              then concatMapStringsSep " " (mod: "${mod}/...") (workspaceConfig.modules or [])
+              else concatMapStringsSep " " (p: "./${p}/...") subPackages;
             testPackages =
               if excludedPackages == []
-              then concatMapStringsSep " " (p: "./${p}/...") subPackages
-              else
-                "$(go list ${concatMapStringsSep " " (p: "./${p}/...") subPackages}"
-                + " | grep -v ${concatMapStringsSep " | grep -v " (p: escapeShellArg p) excludedPackages})";
+              then workspaceTestTargets
+              else "$(go list ${workspaceTestTargets} | grep -v ${concatMapStringsSep " | grep -v " (p: escapeShellArg p) excludedPackages})";
           in
             attrs.checkPhase or ''
               runHook preCheck

--- a/examples/go-workspace/default.nix
+++ b/examples/go-workspace/default.nix
@@ -15,12 +15,4 @@ pkgs.buildGoWorkspace {
   # which one to build.
   subPackages = ["server"];
   doCheck = true;
-
-  # ./... does not resolve from the workspace root — use ./mood/... to target
-  # the module directory directly.
-  checkPhase = ''
-    runHook preCheck
-    go test ./mood/...
-    runHook postCheck
-  '';
 }


### PR DESCRIPTION
closes #357