### PR TITLE
fix(builder): set GOTOOLCHAIN=local to prevent toolchain downloads

### DIFF
--- a/builder/default.nix
+++ b/builder/default.nix
@@ -357,6 +357,7 @@
               inherit GOOS GOARCH CGO_ENABLED;
 
               GO111MODULE = "on";
+              GOTOOLCHAIN = "local";
               GOFLAGS =
                 optionalString useVendor "-mod=vendor"
                 + optionalString (!allowGoReference) (optionalString useVendor " " + "-trimpath");
@@ -671,6 +672,7 @@
               inherit GOOS GOARCH CGO_ENABLED;
 
               GO111MODULE = "on";
+              GOTOOLCHAIN = "local";
               GOFLAGS =
                 lib.optionalString useVendor "-mod=vendor"
                 + lib.optionalString (!allowGoReference) (lib.optionalString useVendor " " + "-trimpath");

--- a/lib/mk-go-tool.nix
+++ b/lib/mk-go-tool.nix
@@ -40,6 +40,7 @@ in
     env = {
       inherit (go) GOOS GOARCH CGO_ENABLED;
       GO111MODULE = "on";
+      GOTOOLCHAIN = "local";
       GOFLAGS = "-mod=vendor -trimpath";
       GODEBUG = lib.optionalString (lib.versionAtLeast go.version "1.25") "embedfollowsymlinks=1";
     };


### PR DESCRIPTION
closes #376

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized Go toolchain configuration to consistently use the local toolchain across all build operations, improving build reproducibility and predictability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->