### PR TITLE
docs: add missing localReplaces entry for buildGoWorkspace within the docs

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -144,6 +144,7 @@ Build applications from a Go workspace (`go.work`).
 | `ldflags`          | `[]`                | Linker flags                                               |
 | `tags`             | `[]`                | Build tags                                                 |
 | `allowGoReference` | `false`             | Allow Go toolchain in runtime closure                      |
+| `localReplaces`    | `{}`                | Map of module path to Nix path for external local replaces |
 | `netrcFile`        | `null`              | Path to a `.netrc` file for private module authentication  |
 | `GOPRIVATE`        | `""`                | Module path prefixes to bypass the proxy and checksum DB   |
 | `GONOSUMDB`        | `""`                | Module path prefixes to bypass the checksum DB only        |


### PR DESCRIPTION
closes #389

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the `localReplaces` configuration option, enabling users to map external modules in their build configuration reference guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->