### PR TITLE
fix(builder): reject workspace vendor builds on Go < 1.22

### DIFF
--- a/builder/default.nix
+++ b/builder/default.nix
@@ -805,6 +805,14 @@
 
         Alternatively, commit a vendor directory using 'go work vendor'.
     '';
+    assert (!(useVendor && (useManifest || pathExists (src + "/go.work"))) || lib.versionAtLeast go.version "1.22")
+    || throw ''
+      buildGoWorkspace: vendoring in workspace mode (go.work present) requires Go 1.22 or later.
+
+      Go ${go.version} does not support -mod=vendor when a go.work file is present.
+
+        Upgrade to Go 1.22 or later, or remove the vendor directory.
+    '';
       stdenv.mkDerivation (
         builtins.removeAttrs attrs ["modules" "subPackages" "ldflags" "tags" "GOOS" "GOARCH" "CGO_ENABLED" "localReplaces" "netrcFile" "GOPRIVATE" "GONOSUMDB" "GONOPROXY" "allowGoReference" "checkFlags" "excludedPackages" "meta"]
         // {


### PR DESCRIPTION
closes #392

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility checks for Go workspace builds using vendored dependencies: evaluation now enforces a minimum Go 1.22 version when workspace-mode vendoring plus a workspace definition file is present, and provides clearer, actionable error messages recommending upgrading Go or removing the vendor directory to resolve the issue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->