### PR TITLE
fix(builder): set GOWORK=off in buildGoApplication to prevent implicit workspace mode

### DIFF
--- a/builder/default.nix
+++ b/builder/default.nix
@@ -275,6 +275,7 @@
     testPackages, # pre-computed test target string (differs between app and workspace)
     configurePhase, # builder-specific configure phase (pre-computed with attrs fallback)
     passthru, # builder-specific passthru attrs
+    GOWORK ? null, # when set, overrides workspace mode (e.g. "off" for buildGoApplication)
   }: {
     meta = attrs.meta or {};
 
@@ -283,7 +284,7 @@
       ++ [go];
 
     env =
-      attrs.env or {}
+      (attrs.env or {})
       // {
         inherit GOOS GOARCH CGO_ENABLED;
 
@@ -293,7 +294,8 @@
           optionalString useVendor "-mod=vendor"
           + optionalString (!allowGoReference) (optionalString useVendor " " + "-trimpath");
         GODEBUG = lib.optionalString (lib.versionAtLeast go.version "1.25") "embedfollowsymlinks=1";
-      };
+      }
+      // lib.optionalAttrs (GOWORK != null) {inherit GOWORK;};
 
     inherit configurePhase;
 
@@ -506,6 +508,7 @@
         // mkCommonAttrs {
           inherit attrs go allowGoReference ldflags tags GOOS GOARCH CGO_ENABLED;
           inherit useVendor subPackages checkFlags testPackages configurePhase passthru;
+          GOWORK = "off";
         }
       );
 


### PR DESCRIPTION
closes #396

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved Go build environment handling to make application builds explicitly disable workspace mode.
  * Adjusted environment merging so workspace override is added only when present, reducing unintended overrides.
  * Results in more predictable and consistent build behavior between application and workspace builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->