### PR TITLE
chore(ci): scope nix manifest automation commits for auto-merge

### DIFF
--- a/.github/workflows/go-update.yml
+++ b/.github/workflows/go-update.yml
@@ -61,11 +61,11 @@ jobs:
 
             git checkout -b "$branch"
             git add "$manifest"
-            git commit -s -m "chore: generated nix manifest for go release ${version}"
+            git commit -s -m "chore(go): generated nix manifest for go release ${version}"
             git push -u origin "$branch"
 
             gh pr create \
-              --title "chore: add go ${version} manifest" \
+              --title "chore(go): add go ${version} manifest" \
               --body "Auto-generated nix manifest for Go release ${version}." \
               --base main \
               --head "$branch"

--- a/.github/workflows/tools-update.yml
+++ b/.github/workflows/tools-update.yml
@@ -121,11 +121,11 @@ jobs:
 
           git checkout -b "$branch"
           git add "$manifest"
-          git commit -s -m "chore: generated nix manifest for ${name} ${version#v}"
+          git commit -s -m "chore(tool): generated nix manifest for ${name} ${version#v}"
           git push -u origin "$branch"
 
           gh pr create \
-            --title "chore: add ${name} ${version#v} manifest" \
+            --title "chore(tool): add ${name} ${version#v} manifest" \
             --body "Auto-generated nix manifest for ${name} ${version}." \
             --base main \
             --head "$branch"


### PR DESCRIPTION
closes #420

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automation workflows to use scoped Conventional Commit titles for manifest-related updates, improving commit organization and clarity in repository history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->