### PR TITLE
feat(builder)!: default doCheck to true in buildGoApplication and buildGoWorkspace

### DIFF
--- a/builder/default.nix
+++ b/builder/default.nix
@@ -429,7 +429,7 @@
           runHook postBuild
         '';
 
-      doCheck = attrs.doCheck or false;
+      doCheck = attrs.doCheck or true;
 
       checkPhase =
         attrs.checkPhase or ''

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -137,7 +137,7 @@ Build a single-module Go application using vendored dependencies.
 | `GOPRIVATE`        | `""`                | Module path prefixes to bypass the proxy and checksum DB                         |
 | `GONOSUMDB`        | `""`                | Module path prefixes to bypass the checksum DB only                              |
 | `GONOPROXY`        | `""`                | Module path prefixes to bypass the proxy only                                    |
-| `doCheck`          | `false`             | Run tests during the build                                                       |
+| `doCheck`          | `true`              | Run tests during the build                                                       |
 | `checkFlags`       | `[]`                | Additional flags passed to `go test`                                             |
 | `extraGoFlags`     | `[]`                | Additional flags appended to `GOFLAGS` for all `go` commands (e.g. `["-cover"]`) |
 | `excludedPackages` | `[]`                | Packages to exclude from testing                                                 |
@@ -165,7 +165,7 @@ Build applications from a Go workspace (`go.work`).
 | `GOPRIVATE`        | `""`                | Module path prefixes to bypass the proxy and checksum DB                         |
 | `GONOSUMDB`        | `""`                | Module path prefixes to bypass the checksum DB only                              |
 | `GONOPROXY`        | `""`                | Module path prefixes to bypass the proxy only                                    |
-| `doCheck`          | `false`             | Run tests during the build                                                       |
+| `doCheck`          | `true`              | Run tests during the build                                                       |
 | `checkFlags`       | `[]`                | Additional flags passed to `go test`                                             |
 | `extraGoFlags`     | `[]`                | Additional flags appended to `GOFLAGS` for all `go` commands (e.g. `["-cover"]`) |
 | `excludedPackages` | `[]`                | Packages to exclude from testing                                                 |

--- a/examples/build-tags/default.nix
+++ b/examples/build-tags/default.nix
@@ -10,4 +10,5 @@ pkgs.buildGoApplication {
   version = "0.1.0";
   src = ./.;
   modules = ./govendor.toml;
+  doCheck = false;
 }

--- a/examples/cobra-cli/default.nix
+++ b/examples/cobra-cli/default.nix
@@ -20,7 +20,6 @@ in
       src = ./.;
       modules = ./govendor.toml;
       subPackages = ["cmd/doggo"];
-      doCheck = true;
       ldflags = ["-X main.version=${version}"];
 
       # subPackages controls what is built, so the default checkPhase would

--- a/examples/cross-compile/default.nix
+++ b/examples/cross-compile/default.nix
@@ -11,6 +11,7 @@ pkgs.buildGoApplication {
   version = "0.1.0";
   src = ./.;
   modules = ./govendor.toml;
+  doCheck = false;
 
   # CGO_ENABLED = "0" is required for cross-compilation. Pure-Go binaries need
   # no C cross-compiler, no sysroot — just the Go toolchain.

--- a/examples/go-workspace/default.nix
+++ b/examples/go-workspace/default.nix
@@ -14,5 +14,4 @@ pkgs.buildGoWorkspace {
   # The workspace contains two modules (mood, server). subPackages selects
   # which one to build.
   subPackages = ["server"];
-  doCheck = true;
 }

--- a/examples/hello-world/default.nix
+++ b/examples/hello-world/default.nix
@@ -8,4 +8,5 @@ pkgs.buildGoApplication {
   pname = "hello-world";
   version = "0.1.0";
   src = ./.;
+  doCheck = false;
 }

--- a/examples/http-chi-server/default.nix
+++ b/examples/http-chi-server/default.nix
@@ -11,4 +11,5 @@ pkgs.buildGoApplication {
   # The modules parameter points buildGoApplication at the govendor.toml manifest,
   # which pins each external dependency with a hash for integrity verification.
   modules = ./govendor.toml;
+  doCheck = false;
 }

--- a/examples/local-replaces/default.nix
+++ b/examples/local-replaces/default.nix
@@ -8,6 +8,7 @@ pkgs.buildGoApplication {
   version = "0.1.0";
   src = ./.;
   modules = ./govendor.toml;
+  doCheck = false;
 
   # The go.mod replace directive points to ./units — a relative filesystem path
   # that does not exist inside the Nix sandbox. localReplaces maps each locally

--- a/examples/oapi-codegen/default.nix
+++ b/examples/oapi-codegen/default.nix
@@ -9,6 +9,7 @@ pkgs.buildGoApplication {
   version = "0.1.0";
   src = ./.;
   modules = ./govendor.toml;
+  doCheck = false;
 
   # oapi-codegen is declared as a tool directive in go.mod. govendor compiles
   # it for the host platform and injects the binary into nativeBuildInputs,

--- a/examples/sqlc-codegen/default.nix
+++ b/examples/sqlc-codegen/default.nix
@@ -9,6 +9,7 @@ pkgs.buildGoApplication {
   version = "0.1.0";
   src = ./.;
   modules = ./govendor.toml;
+  doCheck = false;
 
   # sqlc is a non-Go tool, so it is provided via nativeBuildInputs rather than
   # the Go tool directive. It is available on $PATH during build phases but is

--- a/examples/vendored/default.nix
+++ b/examples/vendored/default.nix
@@ -10,4 +10,5 @@ pkgs.buildGoApplication {
   pname = "vendored";
   version = "0.1.0";
   src = ./.;
+  doCheck = false;
 }


### PR DESCRIPTION
closes #356

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Build/check phases now run by default for Go applications (previously disabled by default).

* **Documentation**
  * Updated default values for build configuration options.

* **Chores**
  * Updated example projects to explicitly disable checks where needed to maintain expected behavior under new defaults.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/purpleclay/go-overlay/pull/448)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->