### PR TITLE
feat(builder)!: decouple test scope from subPackages in checkPhase

### DIFF
--- a/builder/default.nix
+++ b/builder/default.nix
@@ -30,7 +30,41 @@
     optionalAttrs
     optionalString
     pathExists
+    splitString
     ;
+
+  # Parse workspace member paths from a go.work file's content.
+  # Handles both single-line (use ./path) and block (use (\n  ./path\n)) forms.
+  # Returns a list of path strings, e.g. ["./mood" "./server"].
+  parseGoWorkModules = content: let
+    lines = splitString "\n" content;
+    result =
+      builtins.foldl' (
+        acc: line: let
+          startBlock = builtins.match "[ \t]*use[ \t]+\\([ \t]*" line;
+          endBlock = builtins.match "[ \t]*\\)[ \t]*" line;
+          singleUse = builtins.match "[ \t]*use[ \t]+([^ \t]+)[ \t]*" line;
+          blockEntry = builtins.match "[ \t]*([^ \t/][^ \t]*)[ \t]*" line;
+        in
+          if acc.inBlock
+          then
+            if endBlock != null
+            then acc // {inBlock = false;}
+            else if blockEntry != null
+            then acc // {mods = acc.mods ++ [(builtins.head blockEntry)];}
+            else acc
+          else if startBlock != null
+          then acc // {inBlock = true;}
+          else if singleUse != null
+          then acc // {mods = acc.mods ++ [(builtins.head singleUse)];}
+          else acc
+      ) {
+        inBlock = false;
+        mods = [];
+      }
+      lines;
+  in
+    result.mods;
 
   # Fetch a Go module using `go mod download`.
   # Supports private modules via GOPRIVATE and a netrc file for authentication.
@@ -578,12 +612,13 @@
         ''
       );
 
+    # Test scope is independent of build scope: tests run across the entire
+    # module by default, regardless of which subPackages are built. Filter
+    # specific packages out via excludedPackages.
     testPackages =
       if excludedPackages == []
-      then concatMapStringsSep " " (p: "./${p}/...") subPackages
-      else
-        "$(go list ${concatMapStringsSep " " (p: "./${p}/...") subPackages}"
-        + " | grep -F -v -- ${concatMapStringsSep " | grep -F -v -- " (p: escapeShellArg p) excludedPackages})";
+      then "./..."
+      else "$(go list ./... | grep -F -v -- ${concatMapStringsSep " | grep -F -v -- " (p: escapeShellArg p) excludedPackages} || echo './...')";
 
     # Build each declared tool for the host platform so it lands in $PATH
     # during preBuild without any user configuration.
@@ -895,17 +930,26 @@
       );
 
     # In workspace mode, go test ./... does not expand across module boundaries.
-    # Instead, derive test targets from the workspace modules listed in go.work.
-    # Falls back to subPackages if no workspace config is present (in-tree vendor mode).
+    # Instead, derive test targets from the workspace modules listed in go.work
+    # so the entire workspace is tested by default — independent of subPackages.
+    # In in-tree vendor mode (no manifest), parse go.work directly to recover
+    # member paths; ./... is the last-resort fallback if go.work is absent.
+    inTreeWorkspaceModules =
+      if useInTreeVendor && pathExists (src + "/go.work")
+      then parseGoWorkModules (readFile (src + "/go.work"))
+      else [];
+
     workspaceTestTargets =
       if workspaceConfig != null
       then concatMapStringsSep " " (mod: "${mod}/...") (workspaceConfig.modules or [])
-      else concatMapStringsSep " " (p: "./${p}/...") subPackages;
+      else if inTreeWorkspaceModules != []
+      then concatMapStringsSep " " (mod: "${mod}/...") inTreeWorkspaceModules
+      else "./...";
 
     testPackages =
       if excludedPackages == []
       then workspaceTestTargets
-      else "$(go list ${workspaceTestTargets} | grep -F -v -- ${concatMapStringsSep " | grep -F -v -- " (p: escapeShellArg p) excludedPackages})";
+      else "$(go list ${workspaceTestTargets} | grep -F -v -- ${concatMapStringsSep " | grep -F -v -- " (p: escapeShellArg p) excludedPackages} || echo ${escapeShellArg workspaceTestTargets})";
 
     # Build each declared tool for the host platform so it lands in $PATH
     # during preBuild without any user configuration.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -128,7 +128,7 @@ Build a single-module Go application using vendored dependencies.
 | `src`              | required            | Source directory                                                                 |
 | `go`               | required            | Go derivation from go-overlay                                                    |
 | `modules`          | `null`              | Path to govendor.toml manifest (null = use in-tree vendor)                       |
-| `subPackages`      | `["."]`             | Packages to build (relative to src)                                              |
+| `subPackages`      | `["."]`             | Packages to build (relative to src). Does not affect test scope.                 |
 | `ldflags`          | `[]`                | Linker flags                                                                     |
 | `tags`             | `[]`                | Build tags                                                                       |
 | `allowGoReference` | `false`             | Allow Go toolchain in runtime closure                                            |
@@ -140,7 +140,7 @@ Build a single-module Go application using vendored dependencies.
 | `doCheck`          | `true`              | Run tests during the build                                                       |
 | `checkFlags`       | `[]`                | Additional flags passed to `go test`                                             |
 | `extraGoFlags`     | `[]`                | Additional flags appended to `GOFLAGS` for all `go` commands (e.g. `["-cover"]`) |
-| `excludedPackages` | `[]`                | Packages to exclude from testing                                                 |
+| `excludedPackages` | `[]`                | Packages to exclude from `go test` (the default test scope is `./...`)           |
 | `CGO_ENABLED`      | inherited from `go` | Enable CGO                                                                       |
 | `GOOS`             | inherited from `go` | Target operating system                                                          |
 | `GOARCH`           | inherited from `go` | Target architecture                                                              |
@@ -149,29 +149,29 @@ Build a single-module Go application using vendored dependencies.
 
 Build applications from a Go workspace (`go.work`).
 
-| Option             | Default             | Description                                                                      |
-| :----------------- | :------------------ | :------------------------------------------------------------------------------- |
-| `pname`            | required            | Package name                                                                     |
-| `version`          | required            | Package version                                                                  |
-| `src`              | required            | Source directory (workspace root)                                                |
-| `go`               | required            | Go derivation from go-overlay                                                    |
-| `modules`          | `null`              | Path to govendor.toml manifest (null = use in-tree vendor)                       |
-| `subPackages`      | `["."]`             | Packages to build (relative to workspace root)                                   |
-| `ldflags`          | `[]`                | Linker flags                                                                     |
-| `tags`             | `[]`                | Build tags                                                                       |
-| `allowGoReference` | `false`             | Allow Go toolchain in runtime closure                                            |
-| `localReplaces`    | `{}`                | Map of module path to Nix path for external local replaces                       |
-| `netrcFile`        | `null`              | Path to a `.netrc` file for private module authentication                        |
-| `GOPRIVATE`        | `""`                | Module path prefixes to bypass the proxy and checksum DB                         |
-| `GONOSUMDB`        | `""`                | Module path prefixes to bypass the checksum DB only                              |
-| `GONOPROXY`        | `""`                | Module path prefixes to bypass the proxy only                                    |
-| `doCheck`          | `true`              | Run tests during the build                                                       |
-| `checkFlags`       | `[]`                | Additional flags passed to `go test`                                             |
-| `extraGoFlags`     | `[]`                | Additional flags appended to `GOFLAGS` for all `go` commands (e.g. `["-cover"]`) |
-| `excludedPackages` | `[]`                | Packages to exclude from testing                                                 |
-| `CGO_ENABLED`      | inherited from `go` | Enable CGO                                                                       |
-| `GOOS`             | inherited from `go` | Target operating system                                                          |
-| `GOARCH`           | inherited from `go` | Target architecture                                                              |
+| Option             | Default             | Description                                                                                                                                    |
+| :----------------- | :------------------ | :--------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pname`            | required            | Package name                                                                                                                                   |
+| `version`          | required            | Package version                                                                                                                                |
+| `src`              | required            | Source directory (workspace root)                                                                                                              |
+| `go`               | required            | Go derivation from go-overlay                                                                                                                  |
+| `modules`          | `null`              | Path to govendor.toml manifest (null = use in-tree vendor)                                                                                     |
+| `subPackages`      | `["."]`             | Packages to build (relative to workspace root). Does not affect test scope.                                                                    |
+| `ldflags`          | `[]`                | Linker flags                                                                                                                                   |
+| `tags`             | `[]`                | Build tags                                                                                                                                     |
+| `allowGoReference` | `false`             | Allow Go toolchain in runtime closure                                                                                                          |
+| `localReplaces`    | `{}`                | Map of module path to Nix path for external local replaces                                                                                     |
+| `netrcFile`        | `null`              | Path to a `.netrc` file for private module authentication                                                                                      |
+| `GOPRIVATE`        | `""`                | Module path prefixes to bypass the proxy and checksum DB                                                                                       |
+| `GONOSUMDB`        | `""`                | Module path prefixes to bypass the checksum DB only                                                                                            |
+| `GONOPROXY`        | `""`                | Module path prefixes to bypass the proxy only                                                                                                  |
+| `doCheck`          | `true`              | Run tests during the build                                                                                                                     |
+| `checkFlags`       | `[]`                | Additional flags passed to `go test`                                                                                                           |
+| `extraGoFlags`     | `[]`                | Additional flags appended to `GOFLAGS` for all `go` commands (e.g. `["-cover"]`)                                                               |
+| `excludedPackages` | `[]`                | Packages to exclude from `go test` (default test scope is each workspace member's `./mod/...`; in in-tree vendor mode, members are parsed from `go.work`) |
+| `CGO_ENABLED`      | inherited from `go` | Enable CGO                                                                                                                                     |
+| `GOOS`             | inherited from `go` | Target operating system                                                                                                                        |
+| `GOARCH`           | inherited from `go` | Target architecture                                                                                                                            |
 
 ### `mkVendorEnv`
 

--- a/examples/cobra-cli/README.md
+++ b/examples/cobra-cli/README.md
@@ -11,54 +11,40 @@ nix run .#example-cobra-cli -- suggest
 ## The Nix bit
 
 ```nix
-let
+{
+  pkgs,
+  go,
+}: let
   version = "0.1.0";
-  # checkFlags are threaded into the custom checkPhase manually.
-  checkFlags = [
-    "-race"       # detect race conditions
-    "-shuffle=on" # randomise test order to surface order-dependent failures
-    "-vet=off"    # vet runs separately as a lint step
-  ];
 in
-  {
-    pkgs,
-    go,
-  }:
-    pkgs.buildGoApplication {
-      inherit go version checkFlags;
+  pkgs.buildGoApplication {
+    inherit go version;
 
-      pname = "doggo";
-      src = ./.;
-      modules = ./govendor.toml;
+    pname = "doggo";
+    src = ./.;
+    modules = ./govendor.toml;
+    subPackages = ["cmd/doggo"];
+    ldflags = ["-X main.version=${version}"];
 
-      # The main package lives under cmd/doggo rather than at the module root.
-      subPackages = ["cmd/doggo"];
+    # checkFlags are passed to go test by the default checkPhase, which now
+    # tests the entire module (./...) regardless of subPackages.
+    checkFlags = [
+      "-race" # detect race conditions
+      "-shuffle=on" # randomise test execution order to surface order-dependent failures
+    ];
 
-      # Inject the version string at link time.
-      ldflags = ["-X main.version=${version}"];
-
-      # subPackages scopes the default checkPhase to ./cmd/... — override it to
-      # test internal/suggest directly. cmd/doggo is excluded because go:embed
-      # requires the static images to be present at compile time.
-      doCheck = true;
-      checkPhase = ''
-        runHook preCheck
-        go test ${builtins.concatStringsSep " " checkFlags} ./internal/suggest/...
-        runHook postCheck
-      '';
-
-      # Cobra generates shell completions for bash, zsh, and fish automatically.
-      # postInstall runs after the binary lands in $out/bin, so the binary can
-      # be invoked here to produce and install the completion files.
-      # Plain redirection is used instead of process substitution — the Nix
-      # sandbox restricts /dev/fd, which <(...) depends on.
-      postInstall = ''
-        mkdir -p $out/share/bash-completion/completions
-        mkdir -p $out/share/zsh/site-functions
-        mkdir -p $out/share/fish/vendor_completions.d
-        $out/bin/doggo completion bash > $out/share/bash-completion/completions/doggo
-        $out/bin/doggo completion zsh  > $out/share/zsh/site-functions/_doggo
-        $out/bin/doggo completion fish > $out/share/fish/vendor_completions.d/doggo.fish
-      '';
-    }
+    # Cobra generates shell completions automatically for any CLI built with it.
+    # postInstall runs after the binary is installed to $out/bin, so the binary
+    # can be invoked here to produce and install the completion files.
+    # Plain redirection is used instead of process substitution — the Nix
+    # sandbox restricts /dev/fd, which <(...) depends on.
+    postInstall = ''
+      mkdir -p $out/share/bash-completion/completions
+      mkdir -p $out/share/zsh/site-functions
+      mkdir -p $out/share/fish/vendor_completions.d
+      $out/bin/doggo completion bash > $out/share/bash-completion/completions/doggo
+      $out/bin/doggo completion zsh  > $out/share/zsh/site-functions/_doggo
+      $out/bin/doggo completion fish > $out/share/fish/vendor_completions.d/doggo.fish
+    '';
+  }
 ```

--- a/examples/cobra-cli/default.nix
+++ b/examples/cobra-cli/default.nix
@@ -1,47 +1,36 @@
-let
+{
+  pkgs,
+  go,
+}: let
   version = "0.1.0";
-  # checkFlags are passed to go test. With a custom checkPhase (see below),
-  # thread them through manually; with the default checkPhase they are applied
-  # automatically.
-  checkFlags = [
-    "-race" # detect race conditions
-    "-shuffle=on" # randomise test execution order to surface order-dependent failures
-    "-vet=off" # disable vet during testing — vet is run as a separate lint step
-  ];
 in
-  {
-    pkgs,
-    go,
-  }:
-    pkgs.buildGoApplication {
-      inherit go version checkFlags;
+  pkgs.buildGoApplication {
+    inherit go version;
 
-      pname = "doggo";
-      src = ./.;
-      modules = ./govendor.toml;
-      subPackages = ["cmd/doggo"];
-      ldflags = ["-X main.version=${version}"];
+    pname = "doggo";
+    src = ./.;
+    modules = ./govendor.toml;
+    subPackages = ["cmd/doggo"];
+    ldflags = ["-X main.version=${version}"];
 
-      # subPackages controls what is built, so the default checkPhase would
-      # only test ./cmd/... — override it to test the suggest package directly.
-      # cmd/doggo is excluded because go:embed requires images at compile time.
-      checkPhase = ''
-        runHook preCheck
-        go test ${builtins.concatStringsSep " " checkFlags} ./internal/suggest/...
-        runHook postCheck
-      '';
+    # checkFlags are passed to go test by the default checkPhase, which now
+    # tests the entire module (./...) regardless of subPackages.
+    checkFlags = [
+      "-race" # detect race conditions
+      "-shuffle=on" # randomise test execution order to surface order-dependent failures
+    ];
 
-      # Cobra generates shell completions automatically for any CLI built with it.
-      # postInstall runs after the binary is installed to $out/bin, so the binary
-      # can be invoked here to produce and install the completion files.
-      # Plain redirection is used instead of process substitution — the Nix
-      # sandbox restricts /dev/fd, which <(...) depends on.
-      postInstall = ''
-        mkdir -p $out/share/bash-completion/completions
-        mkdir -p $out/share/zsh/site-functions
-        mkdir -p $out/share/fish/vendor_completions.d
-        $out/bin/doggo completion bash > $out/share/bash-completion/completions/doggo
-        $out/bin/doggo completion zsh  > $out/share/zsh/site-functions/_doggo
-        $out/bin/doggo completion fish > $out/share/fish/vendor_completions.d/doggo.fish
-      '';
-    }
+    # Cobra generates shell completions automatically for any CLI built with it.
+    # postInstall runs after the binary is installed to $out/bin, so the binary
+    # can be invoked here to produce and install the completion files.
+    # Plain redirection is used instead of process substitution — the Nix
+    # sandbox restricts /dev/fd, which <(...) depends on.
+    postInstall = ''
+      mkdir -p $out/share/bash-completion/completions
+      mkdir -p $out/share/zsh/site-functions
+      mkdir -p $out/share/fish/vendor_completions.d
+      $out/bin/doggo completion bash > $out/share/bash-completion/completions/doggo
+      $out/bin/doggo completion zsh  > $out/share/zsh/site-functions/_doggo
+      $out/bin/doggo completion fish > $out/share/fish/vendor_completions.d/doggo.fish
+    '';
+  }

--- a/goscrape.nix
+++ b/goscrape.nix
@@ -14,6 +14,12 @@ in
     modules = ./govendor.toml;
     subPackages = ["cmd/goscrape"];
     CGO_ENABLED = 0;
+
+    # Integration tests in internal/vendor shell out to `go mod download`,
+    # which needs network access. The Nix sandbox enforces GOPROXY=off,
+    # so these tests cannot run here. CI runs the full suite via
+    # `go test` outside the sandbox.
+    doCheck = false;
     ldflags = [
       "-s"
       "-w"

--- a/govendor.nix
+++ b/govendor.nix
@@ -14,6 +14,12 @@ in
     modules = ./govendor.toml;
     subPackages = ["cmd/govendor"];
     CGO_ENABLED = 0;
+
+    # Integration tests in internal/vendor and internal/resolve shell out to
+    # `go mod download`, which needs network access. The Nix sandbox enforces
+    # GOPROXY=off, so these tests cannot run here. CI runs the full suite via
+    # `go test` outside the sandbox.
+    doCheck = false;
     ldflags = [
       "-s"
       "-w"


### PR DESCRIPTION
closes #377

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated test scoping defaults for Go applications and workspaces
  * Improved excluded package filtering logic

* **Documentation**
  * Clarified test scope behavior and `subPackages` impact in reference documentation
  * Simplified cobra-cli example configuration
  * Added notes on test execution limitations in examples requiring network access

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/purpleclay/go-overlay/pull/452)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->