### PR TITLE
fix(tools): handle pre-release version specifiers in tool manifest sorting

### DIFF
--- a/lib/tool-manifests.nix
+++ b/lib/tool-manifests.nix
@@ -10,16 +10,35 @@
     (name: type: type == "directory" && name != "go")
     allEntries;
 
-  # Parse semver "major.minor.patch" into comparable components
+  # Parse semver "major.minor.patch" into comparable components.
+  # Handles pre-release suffixes like "0.22.0-pre.2" where the patch segment
+  # contains a hyphen (e.g. "0-pre") followed by an optional numeric pre-release
+  # counter as the next dot-separated part.
   parseToolVersion = v: let
     parts = lib.splitString "." v;
+    patchStr =
+      if builtins.length parts > 2
+      then builtins.elemAt parts 2
+      else "0";
+    # Split "0-pre" → ["0" "pre"]; plain "3" → ["3"]
+    patchParts = lib.splitString "-" patchStr;
+    isPreRelease = builtins.length patchParts > 1;
+    # The numeric counter after the last dot in a pre-release, e.g. the "2" in "0.22.0-pre.2".
+    # Guard against non-numeric suffixes (e.g. -pre.rc1) to avoid a toInt evaluation crash.
+    preNum =
+      if isPreRelease && builtins.length parts > 3
+      then let
+        prePart = builtins.elemAt parts 3;
+      in
+        if builtins.match "[0-9]+" prePart != null
+        then lib.toInt prePart
+        else 0
+      else 0;
   in {
     major = lib.toInt (builtins.elemAt parts 0);
     minor = lib.toInt (builtins.elemAt parts 1);
-    patch =
-      if builtins.length parts > 2
-      then lib.toInt (builtins.elemAt parts 2)
-      else 0;
+    patch = lib.toInt (builtins.head patchParts);
+    inherit isPreRelease preNum;
   };
 
   compareToolVersions = a: b: let
@@ -30,7 +49,16 @@
     then va.major - vb.major
     else if va.minor != vb.minor
     then va.minor - vb.minor
-    else va.patch - vb.patch;
+    else if va.patch != vb.patch
+    then va.patch - vb.patch
+    # Same base version: release sorts above pre-release
+    else if va.isPreRelease != vb.isPreRelease
+    then
+      if va.isPreRelease
+      then -1
+      else 1
+    # Both pre-release: higher counter wins
+    else va.preNum - vb.preNum;
 
   # Load all manifests for a single tool directory
   loadTool = toolName: let

--- a/test/default.nix
+++ b/test/default.nix
@@ -1,6 +1,37 @@
 {pkgs}: let
   go-bin = pkgs.go-bin;
 
+  # Direct access to tool-manifests internals for ordering assertions
+  toolManifests = import ../lib/tool-manifests.nix {lib = pkgs.lib;};
+
+  # Returns the index of x in xs, or null if not found.
+  # Returning null (rather than a sentinel integer) ensures ordering assertions
+  # fail explicitly when an expected version is absent from the list.
+  indexOf = xs: x: let
+    res =
+      builtins.foldl'
+      (acc: v:
+        if acc.done
+        then acc
+        else if v == x
+        then {
+          done = true;
+          i = acc.i;
+        }
+        else {
+          done = false;
+          i = acc.i + 1;
+        })
+      {
+        done = false;
+        i = 0;
+      }
+      xs;
+  in
+    if res.done
+    then res.i
+    else null;
+
   assertEq = name: expected: actual:
     if expected == actual
     then pkgs.runCommand "test-${name}-pass" {} "touch $out"
@@ -98,4 +129,24 @@ in {
   # withDefaultTools - bundles toolchain with curated default tools into a single derivation
   # Binary existence is verified in CI via the build-with-default-tools matrix job
   withDefaultTools-is-derivation = assertEq "withDefaultTools-is-derivation" true (builtins.isAttrs go-bin.latest.withDefaultTools);
+
+  # tools - pre-release version handling (gopls 0.22.0-pre.*)
+  # Accessing a pre-release version by its full key must not throw
+  tools-gopls-pre-release-accessible = assertEq "tools-gopls-pre-release-accessible" "0.22.0-pre.2" go-bin.latest.tools.gopls."0.22.0-pre.2".version;
+
+  # Higher pre-release counter sorts above lower counter for the same base version
+  tools-gopls-pre-release-counter-ordering = let
+    sorted = toolManifests.tools.gopls.sortedVersions;
+    pre2 = indexOf sorted "0.22.0-pre.2";
+    pre1 = indexOf sorted "0.22.0-pre.1";
+  in
+    assertEq "tools-gopls-pre-release-counter-ordering" true (pre2 != null && pre1 != null && pre2 < pre1);
+
+  # Pre-release of a higher minor version sorts above a stable release of a lower minor version
+  tools-gopls-pre-release-above-older-stable = let
+    sorted = toolManifests.tools.gopls.sortedVersions;
+    pre2 = indexOf sorted "0.22.0-pre.2";
+    stable = indexOf sorted "0.21.1";
+  in
+    assertEq "tools-gopls-pre-release-above-older-stable" true (pre2 != null && stable != null && pre2 < stable);
 }


### PR DESCRIPTION
closes #453

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tool version system now recognizes pre-release suffixes (e.g., `0.22.0-pre.2`) and treats them distinctly from stable releases.
  * Version comparison updated to order stable releases above pre-releases and to order pre-releases by their numeric counter.

* **Tests**
  * Added tests for pre-release key lookup, ordering between pre-release counters, and cross-version ordering between pre-releases and stable releases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/purpleclay/go-overlay/pull/455)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/purpleclay/go-overlay/pull/455)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->