### PR TITLE
feat(govendor): validate govendor.toml structure on parse

### DIFF
--- a/internal/vendor/manifest.go
+++ b/internal/vendor/manifest.go
@@ -1,6 +1,8 @@
 package vendor
 
 import (
+	"errors"
+	"fmt"
 	"io"
 	"slices"
 
@@ -57,11 +59,37 @@ func Parse(data []byte) (*Manifest, error) {
 	if err := toml.Unmarshal(data, &m); err != nil {
 		return nil, err
 	}
+	if err := validateManifest(&m); err != nil {
+		return nil, err
+	}
 	for path, cfg := range m.Mod {
 		cfg.Path = path
 		m.Mod[path] = cfg
 	}
 	return &m, nil
+}
+
+func validateManifest(m *Manifest) error {
+	if m.Schema == 0 {
+		return errors.New("govendor.toml: missing required 'schema' field")
+	}
+	if m.Mod == nil {
+		return errors.New("govendor.toml: missing required '[mod]' section")
+	}
+	if m.Workspace != nil {
+		if m.Workspace.Go == "" {
+			return errors.New("govendor.toml: [workspace] missing required 'go' field")
+		}
+		if len(m.Workspace.Modules) == 0 {
+			return errors.New("govendor.toml: [workspace] missing required 'modules' field")
+		}
+	}
+	for pkg, cfg := range m.Tool {
+		if cfg.Version == "" {
+			return fmt.Errorf("govendor.toml: [tool.%q] missing required 'version' field", pkg)
+		}
+	}
+	return nil
 }
 
 // WriteTo encodes the manifest as TOML into w.

--- a/internal/vendor/manifest_test.go
+++ b/internal/vendor/manifest_test.go
@@ -67,6 +67,63 @@ func TestParseWithWorkspace(t *testing.T) {
 	assert.Equal(t, []string{"github.com/fatih/color"}, dep.Packages)
 }
 
+func TestParseValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		data    string
+		wantErr string
+	}{
+		{
+			name:    "MissingSchema",
+			data:    `[mod]`,
+			wantErr: "missing required 'schema' field",
+		},
+		{
+			name:    "MissingModSection",
+			data:    `schema = 3`,
+			wantErr: "missing required '[mod]' section",
+		},
+		{
+			name: "WorkspaceMissingGo",
+			data: `schema = 3
+
+[workspace]
+  modules = ["./api"]
+
+[mod]`,
+			wantErr: "[workspace] missing required 'go' field",
+		},
+		{
+			name: "WorkspaceMissingModules",
+			data: `schema = 3
+
+[workspace]
+  go = "1.26.0"
+
+[mod]`,
+			wantErr: "[workspace] missing required 'modules' field",
+		},
+		{
+			name: "ToolMissingVersion",
+			data: `schema = 3
+
+[tool]
+  [tool."golang.org/x/tools/cmd/stringer"]
+
+[mod]`,
+			wantErr: "missing required 'version' field",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := vendor.Parse([]byte(tt.data))
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
 func TestWriteTo(t *testing.T) {
 	manifest := vendor.New(
 		[]mod.ModuleConfig{


### PR DESCRIPTION
closes #462

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Manifest parsing now validates required configuration fields (schema, modules, workspace settings, and tool versions) with improved error messages to help identify configuration issues faster.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/purpleclay/go-overlay/pull/465?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->