### PR TITLE
feat(govendor)!: remove the --force flag

### DIFF
--- a/internal/cli/govendor/root.go
+++ b/internal/cli/govendor/root.go
@@ -14,7 +14,6 @@ import (
 func Execute(version cli.VersionInfo) error {
 	var (
 		check            bool
-		force            bool
 		recursive        bool
 		workspace        bool
 		depth            int
@@ -61,9 +60,6 @@ func Execute(version cli.VersionInfo) error {
 
 		# Include additional platforms for cross-compilation
 		govendor --include-platform=freebsd/amd64 --include-platform=openbsd/amd64
-
-		# Force regeneration of govendor.toml, bypassing hash check
-		govendor --force
 		`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
@@ -80,10 +76,6 @@ func Execute(version cli.VersionInfo) error {
 
 			if check {
 				opts = append(opts, vendor.WithDriftDetection())
-			}
-
-			if force {
-				opts = append(opts, vendor.WithForce())
 			}
 
 			if recursive {
@@ -113,13 +105,11 @@ func Execute(version cli.VersionInfo) error {
 	}
 
 	cmd.Flags().BoolVarP(&check, "check", "c", false, "check if manifests have drifted and need updating")
-	cmd.Flags().BoolVarP(&force, "force", "f", false, "force regeneration of govendor.toml, bypassing hash check")
 	cmd.Flags().BoolVarP(&recursive, "recursive", "r", false, "recursively scan for go.mod files (ignores go.work)")
 	cmd.Flags().BoolVarP(&workspace, "workspace", "w", false, "reverse scan from a submodule path for a govendor.toml containing a workspace manifest (requires --check)")
 	cmd.Flags().IntVarP(&depth, "depth", "d", 0, "limit directory traversal depth (0 = unlimited)")
 	cmd.Flags().StringArrayVar(&includePlatforms, "include-platform", nil, "extend platform list for dependency resolution (e.g., freebsd/amd64)")
 	cmd.MarkFlagsMutuallyExclusive("recursive", "workspace")
-	cmd.MarkFlagsMutuallyExclusive("force", "check")
 
 	return cli.Execute(cmd,
 		cli.WithVersionFlag(version),

--- a/internal/vendor/vendor.go
+++ b/internal/vendor/vendor.go
@@ -16,7 +16,6 @@ const vendorFile = "govendor.toml"
 
 type vendorOptions struct {
 	detectDrift    bool
-	force          bool
 	paths          []string
 	recursive      bool
 	maxDepth       int
@@ -29,12 +28,6 @@ type Option func(*vendorOptions)
 func WithDriftDetection() Option {
 	return func(opts *vendorOptions) {
 		opts.detectDrift = true
-	}
-}
-
-func WithForce() Option {
-	return func(opts *vendorOptions) {
-		opts.force = true
 	}
 }
 
@@ -199,7 +192,7 @@ func (v *Vendor) processSource(src dependencySource, displayPath string, workspa
 		return resultDrift(displayPath)
 	}
 
-	if unchanged && !v.opts.force {
+	if unchanged {
 		return resultOK(displayPath)
 	}
 

--- a/internal/vendor/vendor_test.go
+++ b/internal/vendor/vendor_test.go
@@ -301,12 +301,3 @@ func TestVendor_UnchangedManifestSkipsWrite(t *testing.T) {
 	require.Len(t, results, 1)
 	assert.Equal(t, vendor.StatusOK, results[0].Status)
 }
-
-func TestVendorWithForce_RegeneratesUnchangedManifest(t *testing.T) {
-	dir := setupModDir(t, nil)
-	vendorResults(t, dir, &fakeResolver{deps: []mod.ModuleConfig{chiDep}})
-
-	results := vendorResults(t, dir, &fakeResolver{deps: []mod.ModuleConfig{chiDep}}, vendor.WithForce())
-	require.Len(t, results, 1)
-	assert.Equal(t, vendor.StatusGenerated, results[0].Status)
-}


### PR DESCRIPTION
closes #467

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the `--force` flag from the govendor CLI command.
  * Removed the ability to force regeneration of vendor manifests.
  * Simplified vendor drift detection to report success only when generated manifests match existing files exactly, without any override capability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/purpleclay/go-overlay/pull/468?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->