### PR TITLE
overlay: expose overlay file

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Add go-overlay to your `flake.nix` inputs and apply the overlay:
 ```
 
 > [!TIP]
-> Not using flakes? See the [traditional Nix installation guide](docs/reference.md#traditional-nix-installation).
+> Not using flakes? `default.nix` is an overlay. See the [traditional Nix installation guide](docs/reference.md#traditional-nix-installation) for more.
 
 #### 2. Add govendor to your dev shell
 

--- a/flake.nix
+++ b/flake.nix
@@ -19,21 +19,7 @@
     flake-utils,
     git-hooks,
   }: let
-    overlay = final: prev: {
-      go-bin = import ./lib {
-        lib = final.lib;
-        pkgs = final;
-      };
-
-      inherit
-        (final.callPackage ./builder {})
-        buildGoApplication
-        buildGoWorkspace
-        buildGoVendoredApplication
-        buildGoVendoredWorkspace
-        mkVendorEnv
-        ;
-    };
+    overlay = import ./default.nix;
   in
     {
       overlays.default = overlay;


### PR DESCRIPTION
This allows for non-flake users to easily target a file to use as an overlay. Flake interface should remain unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated onboarding guide with clearer instructions for users not using flakes, including references to traditional Nix installation methods.

* **Refactor**
  * Restructured overlay configuration for improved code organization and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->