### PR TITLE
ci: switch to gpg-import-action for GPG key import

### DIFF
--- a/.github/workflows/go-update.yml
+++ b/.github/workflows/go-update.yml
@@ -32,10 +32,10 @@ jobs:
           echo "GO_VERSIONS=$LATEST $PREV" >> $GITHUB_ENV
 
       - name: GPG Import
-        env:
-          GPG_PRIVATE_KEY: "${{ secrets.GPG_PRIVATE_KEY }}"
-          GPG_PASSPHRASE: "${{ secrets.GPG_PASSPHRASE }}"
-        run: nix run github:purpleclay/gpg-import
+        uses: purpleclay/gpg-import-action@a39506c3eff9b02459e033e3551e556934f266fc # v0
+        with:
+          key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Generate Manifests and Create PRs
         env:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,14 +3,12 @@ on:
   push:
     branches:
       - main
-      - v1
     paths:
       - "**.go"
       - "go.mod"
   pull_request:
     branches:
       - main
-      - v1
     paths:
       - "**.go"
       - "go.mod"

--- a/.github/workflows/govendor-update.yml
+++ b/.github/workflows/govendor-update.yml
@@ -39,10 +39,10 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: GPG Import
-        env:
-          GPG_PRIVATE_KEY: ${{ secrets.gpg-private-key }}
-          GPG_PASSPHRASE: ${{ secrets.gpg-passphrase }}
-        run: nix run github:purpleclay/gpg-import
+        uses: purpleclay/gpg-import-action@a39506c3eff9b02459e033e3551e556934f266fc # v0
+        with:
+          key: ${{ secrets.gpg-private-key }}
+          passphrase: ${{ secrets.gpg-passphrase }}
 
       - name: Update govendor.toml
         working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/nix-checks.yml
+++ b/.github/workflows/nix-checks.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - v1
     paths:
       - "flake.nix"
       - "flake.lock"
@@ -16,7 +15,6 @@ on:
   pull_request:
     branches:
       - main
-      - v1
     paths:
       - "flake.nix"
       - "flake.lock"

--- a/.github/workflows/nix-fmt.yml
+++ b/.github/workflows/nix-fmt.yml
@@ -3,13 +3,11 @@ on:
   push:
     branches:
       - main
-      - v1
     paths:
       - "**/*.nix"
   pull_request:
     branches:
       - main
-      - v1
     paths:
       - "**/*.nix"
 

--- a/.github/workflows/nix-go.yml
+++ b/.github/workflows/nix-go.yml
@@ -3,13 +3,11 @@ on:
   push:
     branches:
       - main
-      - v1
     paths:
       - "manifests/go/**"
   pull_request:
     branches:
       - main
-      - v1
     paths:
       - "manifests/go/**"
 

--- a/.github/workflows/nix-packages.yml
+++ b/.github/workflows/nix-packages.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - v1
     paths:
       - "goscrape.nix"
       - "govendor.nix"
@@ -16,7 +15,6 @@ on:
   pull_request:
     branches:
       - main
-      - v1
     paths:
       - "goscrape.nix"
       - "govendor.nix"

--- a/.github/workflows/nix-template.yml
+++ b/.github/workflows/nix-template.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - v1
     paths:
       - "flake.nix"
       - "flake.lock"
@@ -12,7 +11,6 @@ on:
   pull_request:
     branches:
       - main
-      - v1
     paths:
       - "flake.nix"
       - "flake.lock"

--- a/.github/workflows/nix-tools.yml
+++ b/.github/workflows/nix-tools.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - v1
     paths:
       - "manifests/delve/**"
       - "manifests/gofumpt/**"
@@ -17,7 +16,6 @@ on:
   pull_request:
     branches:
       - main
-      - v1
     paths:
       - "manifests/delve/**"
       - "manifests/gofumpt/**"

--- a/.github/workflows/nsv.yml
+++ b/.github/workflows/nsv.yml
@@ -22,10 +22,10 @@ jobs:
           cachix-token: ${{ secrets.GH_CACHIX }}
 
       - name: GPG Import
-        env:
-          GPG_PRIVATE_KEY: "${{ secrets.GPG_PRIVATE_KEY }}"
-          GPG_PASSPHRASE: "${{ secrets.GPG_PASSPHRASE }}"
-        run: nix run github:purpleclay/gpg-import
+        uses: purpleclay/gpg-import-action@a39506c3eff9b02459e033e3551e556934f266fc # v0
+        with:
+          key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Tag
         run: nix run github:purpleclay/nsv -- tag --show

--- a/.github/workflows/tools-update.yml
+++ b/.github/workflows/tools-update.yml
@@ -104,10 +104,10 @@ jobs:
 
       - name: GPG Import
         if: steps.generate.outputs.generated == 'true'
-        env:
-          GPG_PRIVATE_KEY: "${{ secrets.GPG_PRIVATE_KEY }}"
-          GPG_PASSPHRASE: "${{ secrets.GPG_PASSPHRASE }}"
-        run: nix run github:purpleclay/gpg-import
+        uses: purpleclay/gpg-import-action@a39506c3eff9b02459e033e3551e556934f266fc # v0
+        with:
+          key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Create PR
         if: steps.generate.outputs.generated == 'true'

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - v1
     paths-ignore:
       - "LICENSE"
       - ".github/stale.yml"
@@ -15,7 +14,6 @@ on:
   pull_request:
     branches:
       - main
-      - v1
     paths-ignore:
       - "LICENSE"
       - ".github/stale.yml"

--- a/.github/workflows/vendor.yml
+++ b/.github/workflows/vendor.yml
@@ -1,7 +1,7 @@
 name: govendor
 on:
   pull_request:
-    branches: [main, v1]
+    branches: [main]
     paths: ["**/go.mod", "**/go.sum"]
 
 jobs:


### PR DESCRIPTION
closes #482

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Consolidated GPG import steps across CI workflows to use a dedicated reusable action instead of inline commands.
  * Streamlined CI workflow triggers to target the `main` branch only, removing legacy branch configurations from multiple automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->