### PR TITLE
ci: avoid cancelling main pushes for nix-fmt, nix-go and nix-tools

### DIFF
--- a/.github/workflows/nix-fmt.yml
+++ b/.github/workflows/nix-fmt.yml
@@ -13,7 +13,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/nix-go.yml
+++ b/.github/workflows/nix-go.yml
@@ -13,7 +13,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/nix-tools.yml
+++ b/.github/workflows/nix-tools.yml
@@ -29,7 +29,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
closes #483

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration pipeline configuration to improve concurrency handling, ensuring unnecessary job cancellations are minimized during automated testing and builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->