### PR TITLE
fix(govendor): write results table via cmd.OutOrStdout

### DIFF
--- a/govendor.nix
+++ b/govendor.nix
@@ -5,8 +5,8 @@
   commit ? "unknown",
 }: let
   pname = "govendor";
-  version = "v1.0.0";
-  buildDate = "2026-05-13T00:00:00Z";
+  version = "v1.0.1";
+  buildDate = "2026-06-11T00:00:00Z";
 in
   buildGoApplication {
     inherit pname version go;

--- a/internal/cli/govendor/root.go
+++ b/internal/cli/govendor/root.go
@@ -98,7 +98,7 @@ func Execute(version cli.VersionInfo) error {
 			v := vendor.NewVendor(resolver, opts...)
 			results, err := v.VendorFiles(cmd.Context())
 			if len(results) > 0 {
-				fmt.Println(ui.RenderResultsTable(results))
+				fmt.Fprintln(cmd.OutOrStdout(), ui.RenderResultsTable(results))
 			}
 			return err
 		},


### PR DESCRIPTION
closes #473

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version to v1.0.1 and build metadata.
  * Improved internal output handling for consistency with framework standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->