### PR TITLE
fix(builder): match excludedPackages exactly and skip checks when fully excluded

### DIFF
--- a/builder/application.nix
+++ b/builder/application.nix
@@ -8,9 +8,10 @@
   mkHostTool,
   commonRemovedAttrs,
   mkCommonAttrs,
+  mkTestPackages,
 }: let
   inherit (builtins) fromTOML readFile;
-  inherit (lib) concatMapStringsSep escapeShellArg optionalString pathExists;
+  inherit (lib) optionalString pathExists;
 in {
   # Build a single-module Go application from a govendor.toml manifest.
   # Defaults to src + "/govendor.toml" — run `govendor` to generate it.
@@ -76,10 +77,11 @@ in {
         runHook postConfigure
       '';
 
-    testPackages =
-      if excludedPackages == []
-      then "./..."
-      else "$(go list ./... | grep -F -v -- ${concatMapStringsSep " | grep -F -v -- " (p: escapeShellArg p) excludedPackages} || echo './...')";
+    testPackages = mkTestPackages {
+      listCmd = "go list ./...";
+      basePackages = "./...";
+      inherit excludedPackages;
+    };
 
     hostTools = map (pkg:
       mkHostTool {
@@ -146,10 +148,11 @@ in {
           runHook postConfigure
         '';
 
-      testPackages =
-        if excludedPackages == []
-        then "./..."
-        else "$(go list ./... | grep -F -v -- ${concatMapStringsSep " | grep -F -v -- " (p: escapeShellArg p) excludedPackages} || echo './...')";
+      testPackages = mkTestPackages {
+        listCmd = "go list ./...";
+        basePackages = "./...";
+        inherit excludedPackages;
+      };
 
       passthru = {inherit go;};
     in

--- a/builder/common.nix
+++ b/builder/common.nix
@@ -2,7 +2,7 @@
 # - commonRemovedAttrs: builder-owned parameters stripped before passing to stdenv
 # - mkCommonAttrs: env setup, build, check, and install phases shared across builders
 {lib}: let
-  inherit (lib) concatMapStringsSep concatStringsSep escapeShellArg optionalString;
+  inherit (lib) concatStringsSep escapeShellArg optionalString;
 in {
   # Builder-owned parameters stripped from attrs before passing to stdenv.mkDerivation.
   commonRemovedAttrs = [
@@ -114,13 +114,18 @@ in {
 
           export GOFLAGS=''${GOFLAGS//-trimpath/}
 
-          go test \
-            -v \
-            -p $NIX_BUILD_CORES \
-            -vet=off \
-            ${optionalString (tags != []) "-tags=${concatStringsSep "," tags}"} \
-            ${optionalString (checkFlags != []) (concatStringsSep " " checkFlags)} \
-            ${testPackages}
+          testPkgs="${testPackages}"
+          if [ -z "$testPkgs" ]; then
+            echo "go-overlay: skipping checkPhase, excludedPackages excludes all packages"
+          else
+            go test \
+              -v \
+              -p $NIX_BUILD_CORES \
+              -vet=off \
+              ${optionalString (tags != []) "-tags=${concatStringsSep "," tags}"} \
+              ${optionalString (checkFlags != []) (concatStringsSep " " checkFlags)} \
+              $testPkgs
+          fi
 
           runHook postCheck
         '';

--- a/builder/default.nix
+++ b/builder/default.nix
@@ -5,6 +5,7 @@
 #   vendor-env.nix    — mkVendorEnv (constructs the vendor/ directory from a manifest)
 #   host-tool.nix     — mkHostTool, parseGoWorkModules
 #   common.nix        — commonRemovedAttrs, mkCommonAttrs (shared builder infrastructure)
+#   test-packages.nix — mkTestPackages (computes the go test package list, honouring excludedPackages)
 #   application.nix   — buildGoApplication, buildGoVendoredApplication
 #   workspace.nix     — buildGoWorkspace, buildGoVendoredWorkspace
 {
@@ -27,8 +28,10 @@
   commonModule = import ./common.nix {inherit lib;};
   inherit (commonModule) commonRemovedAttrs mkCommonAttrs;
 
+  inherit (import ./test-packages.nix {inherit lib;}) mkTestPackages;
+
   applicationModule = import ./application.nix {
-    inherit lib stdenv mkVendorEnv mkHostTool commonRemovedAttrs mkCommonAttrs;
+    inherit lib stdenv mkVendorEnv mkHostTool commonRemovedAttrs mkCommonAttrs mkTestPackages;
   };
 
   workspaceModule = import ./workspace.nix {
@@ -42,6 +45,7 @@
       parseGoWorkModules
       commonRemovedAttrs
       mkCommonAttrs
+      mkTestPackages
       ;
   };
 in {

--- a/builder/test-packages.nix
+++ b/builder/test-packages.nix
@@ -1,0 +1,35 @@
+# Shared logic for computing the `go test` package list when excludedPackages
+# is set.
+{lib}: let
+  inherit (lib) concatMapStringsSep escapeShellArg trim;
+in {
+  # Build the shell expression used as the test package list.
+  #
+  # listCmd: the `go list` invocation producing the candidate package paths
+  # basePackages: value to use when excludedPackages is empty
+  # excludedPackages: exact import paths to exclude from basePackages
+  #
+  # Excluded paths are matched exactly (grep -Fx) against `go list` output, so
+  # excluding "internal/e2e" does not also exclude "internal/e2e2". If every
+  # package is excluded, the expression evaluates to an empty string rather
+  # than falling back to basePackages.
+  #
+  # A failure from listCmd itself propagates (the build fails), whereas grep
+  # exiting 1 just means every listed package was excluded.
+  mkTestPackages = {
+    listCmd,
+    basePackages,
+    excludedPackages,
+  }:
+    if excludedPackages == []
+    then basePackages
+    else
+      trim ''
+        $(
+          _pkgs="$(${listCmd})" || exit $?
+          printf '%s\n' "$_pkgs" \
+            | grep -Fxv ${concatMapStringsSep " " (p: "-e " + escapeShellArg p) excludedPackages} \
+            || [ $? -eq 1 ]
+        )
+      '';
+}

--- a/builder/workspace.nix
+++ b/builder/workspace.nix
@@ -11,6 +11,7 @@
   parseGoWorkModules,
   commonRemovedAttrs,
   mkCommonAttrs,
+  mkTestPackages,
 }: let
   inherit (builtins) fromTOML readFile;
   inherit (lib) concatMapStringsSep escapeShellArg optionalString pathExists;
@@ -231,10 +232,11 @@ in {
     workspaceTestTargets =
       concatMapStringsSep " " (mod: "${mod}/...") (workspaceConfig.modules or []);
 
-    testPackages =
-      if excludedPackages == []
-      then workspaceTestTargets
-      else "$(go list ${workspaceTestTargets} | grep -F -v -- ${concatMapStringsSep " | grep -F -v -- " (p: escapeShellArg p) excludedPackages} || echo ${escapeShellArg workspaceTestTargets})";
+    testPackages = mkTestPackages {
+      listCmd = "go list ${workspaceTestTargets}";
+      basePackages = workspaceTestTargets;
+      inherit excludedPackages;
+    };
 
     hostTools = map (pkg:
       mkHostTool {
@@ -318,10 +320,11 @@ in {
           then concatMapStringsSep " " (mod: "${mod}/...") workspaceModules
           else "./...";
 
-        testPackages =
-          if excludedPackages == []
-          then workspaceTestTargets
-          else "$(go list ${workspaceTestTargets} | grep -F -v -- ${concatMapStringsSep " | grep -F -v -- " (p: escapeShellArg p) excludedPackages} || echo ${escapeShellArg workspaceTestTargets})";
+        testPackages = mkTestPackages {
+          listCmd = "go list ${workspaceTestTargets}";
+          basePackages = workspaceTestTargets;
+          inherit excludedPackages;
+        };
 
         configurePhase =
           attrs.configurePhase or ''

--- a/test/default.nix
+++ b/test/default.nix
@@ -4,6 +4,9 @@
   # Direct access to tool-manifests internals for ordering assertions
   toolManifests = import ../lib/tool-manifests.nix {lib = pkgs.lib;};
 
+  # Direct access to the testPackages shell-expression builder
+  inherit (import ../builder/test-packages.nix {inherit (pkgs) lib;}) mkTestPackages;
+
   # Returns the index of x in xs, or null if not found.
   # Returning null (rather than a sentinel integer) ensures ordering assertions
   # fail explicitly when an expected version is absent from the list.
@@ -52,6 +55,28 @@
         echo "Test '${name}' failed: ${path} not found in ${drv}"
         exit 1
       fi
+    '';
+
+  # Evaluates the shell expression produced by mkTestPackages and asserts its
+  # output matches expected.
+  testTestPackages = name: {
+    listCmd,
+    basePackages,
+    excludedPackages,
+    expected,
+  }: let
+    expr = mkTestPackages {inherit listCmd basePackages excludedPackages;};
+  in
+    pkgs.runCommand "test-${name}" {} ''
+      actual="${expr}"
+      expected=${pkgs.lib.escapeShellArg expected}
+      if [ "$actual" != "$expected" ]; then
+        echo "Test '${name}' failed"
+        echo "Expected: $expected"
+        echo "Actual: $actual"
+        exit 1
+      fi
+      touch $out
     '';
 in {
   # latest
@@ -149,4 +174,45 @@ in {
     stable = indexOf sorted "0.21.1";
   in
     assertEq "tools-gopls-pre-release-above-older-stable" true (pre2 != null && stable != null && pre2 < stable);
+
+  # excludedPackages - no exclusions returns basePackages unchanged
+  testPackages-no-exclusions = testTestPackages "testPackages-no-exclusions" {
+    listCmd = "printf '%s\\n' a ab b";
+    basePackages = "./...";
+    excludedPackages = [];
+    expected = "./...";
+  };
+
+  # excludedPackages - exact match only, not substring (excluding "a" must not exclude "ab")
+  testPackages-exact-match = testTestPackages "testPackages-exact-match" {
+    listCmd = "printf '%s\\n' a ab b";
+    basePackages = "./...";
+    excludedPackages = ["a"];
+    expected = "ab\nb";
+  };
+
+  # excludedPackages - excluding every package yields an empty result, not basePackages
+  testPackages-all-excluded = testTestPackages "testPackages-all-excluded" {
+    listCmd = "printf '%s\\n' a b";
+    basePackages = "./...";
+    excludedPackages = ["a" "b"];
+    expected = "";
+  };
+
+  # excludedPackages - a failing listCmd must propagate, not be swallowed into an
+  # empty result (which checkPhase would otherwise treat as "all excluded")
+  testPackages-listCmd-failure-propagates = let
+    expr = mkTestPackages {
+      listCmd = "exit 7";
+      basePackages = "./...";
+      excludedPackages = ["a"];
+    };
+  in
+    pkgs.runCommand "test-testPackages-listCmd-failure-propagates" {} ''
+      if (set -e; actual="${expr}"); then
+        echo "Test 'testPackages-listCmd-failure-propagates' failed: expected listCmd failure to propagate"
+        exit 1
+      fi
+      touch $out
+    '';
 }


### PR DESCRIPTION
closes #490

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated test-package selection into a shared helper used by application and workspace builders, and skip running tests when no packages remain.

* **Bug Fixes**
  * Ensure failures from the package-listing command are propagated instead of being masked as “all excluded.”

* **Tests**
  * Added runtime tests covering no exclusions, exact-match exclusions, all-excluded, and list-command failure cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->