### PR TITLE
fix(builder): derive FOD name from full module path for /vN modules

### DIFF
--- a/builder/fetch-module.nix
+++ b/builder/fetch-module.nix
@@ -18,7 +18,7 @@
 }:
 stdenvNoCC.mkDerivation (
   {
-    name = "${baseNameOf goPackagePath}_${version}";
+    name = "${lib.replaceStrings ["/"] ["-"] goPackagePath}_${version}";
     builder = ./fetch.sh;
     inherit goPackagePath version;
     nativeBuildInputs = [


### PR DESCRIPTION
closes #496

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration module naming conventions to improve consistency and reliability in the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->