### PR TITLE
fix(builder): lint shell scripts with shellcheck and enforce formatting with shfmt

### DIFF
--- a/.github/workflows/sh.yml
+++ b/.github/workflows/sh.yml
@@ -1,0 +1,54 @@
+name: sh
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "**/*.sh"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "**/*.sh"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-24.04
+    if: github.actor != 'renovate[bot]'
+    name: shellcheck
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Setup Nix
+        uses: ./.github/actions/setup-nix
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          cachix-token: ${{ secrets.GH_CACHIX }}
+
+      - name: Run Shellcheck
+        run: nix develop -c shellcheck builder/*.sh
+
+  shfmt:
+    runs-on: ubuntu-24.04
+    if: github.actor != 'renovate[bot]'
+    name: shfmt
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Setup Nix
+        uses: ./.github/actions/setup-nix
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          cachix-token: ${{ secrets.GH_CACHIX }}
+
+      - name: Run shfmt
+        run: nix develop -c shfmt -d -i 2 builder/*.sh

--- a/builder/fetch.sh
+++ b/builder/fetch.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export HOME=$(mktemp -d)
+# Variables injected by the Nix fetchGoModule derivation.
+: "${goPackagePath:?}" "${version:?}" "${out:?}"
+
+HOME=$(mktemp -d)
+export HOME
 export GOPATH="$HOME/go"
 export GOCACHE="$HOME/go-cache"
 
@@ -9,7 +13,7 @@ export GOCACHE="$HOME/go-cache"
 # Both Go's HTTP client and git (via libcurl) read ~/.netrc for credentials
 # when accessing private module hosts.
 if [ -n "${NETRC_CONTENT:-}" ]; then
-  printf '%s' "$NETRC_CONTENT" > "$HOME/.netrc"
+  printf '%s' "$NETRC_CONTENT" >"$HOME/.netrc"
   chmod 600 "$HOME/.netrc"
 fi
 

--- a/flake.nix
+++ b/flake.nix
@@ -63,6 +63,8 @@
           ])
           nil
           self.packages.${system}.govendor
+          shellcheck
+          shfmt
           typos
         ];
 
@@ -91,6 +93,20 @@
                 "templates/"
               ];
               pass_filenames = true;
+            };
+
+            shellcheck = {
+              enable = true;
+              entry = "${pkgs.shellcheck}/bin/shellcheck";
+              files = "\\.sh$";
+              excludes = ["^examples/vendored/"];
+            };
+
+            shfmt = {
+              enable = true;
+              entry = "${pkgs.shfmt}/bin/shfmt -d -i 2";
+              files = "\\.sh$";
+              excludes = ["^examples/vendored/"];
             };
 
             typos = {


### PR DESCRIPTION
closes #494

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added a new CI workflow to automatically lint and format shell scripts on changes to `.sh` files targeting `main`.
  * Included `shellcheck` and `shfmt` in the development environment and enabled them in pre-commit checks.
  * Strengthened the build script by enforcing required inputs and improving dependency isolation via a temporary `HOME` and scoped Go cache/download directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->