### PR TITLE
refactor(lib): extract shared version parsing into lib/version.nix

### DIFF
--- a/lib/manifests.nix
+++ b/lib/manifests.nix
@@ -1,4 +1,6 @@
 {lib}: let
+  inherit (import ./version.nix {inherit lib;}) parseVersion compareVersions;
+
   # Load all manifest files from the manifests directory
   manifestDir = ../manifests/go;
   manifestFiles = builtins.readDir manifestDir;
@@ -20,48 +22,6 @@
     in
       lib.nameValuePair version (loadManifest filename))
     nixFiles;
-
-  # Parse version string into components (major, minor, patch, rc) for comparison
-  # Handles both stable versions (1.21.6) and release candidates (1.25rc1)
-  parseVersion = v: let
-    parts = lib.splitString "." v;
-    major = lib.toInt (builtins.elemAt parts 0);
-
-    # The minor component may contain an "rc" suffix (e.g., "25rc1")
-    minorPart = builtins.elemAt parts 1;
-    hasRc = builtins.match "([0-9]+)rc([0-9]+)" minorPart;
-  in
-    if hasRc != null
-    then {
-      inherit major;
-      minor = lib.toInt (builtins.elemAt hasRc 0);
-      patch = 0;
-      # RC versions sort before stable, so use negative values
-      # -1000 + rcNum ensures rc1 < rc2 < rc3 < stable (patch 0)
-      rc = -1000 + lib.toInt (builtins.elemAt hasRc 1);
-    }
-    else {
-      inherit major;
-      minor = lib.toInt minorPart;
-      patch =
-        if builtins.length parts > 2
-        then lib.toInt (builtins.elemAt parts 2)
-        else 0;
-      rc = 0;
-    };
-
-  # Compare two version strings
-  compareVersions = a: b: let
-    va = parseVersion a;
-    vb = parseVersion b;
-  in
-    if va.major != vb.major
-    then va.major - vb.major
-    else if va.minor != vb.minor
-    then va.minor - vb.minor
-    else if va.patch != vb.patch
-    then va.patch - vb.patch
-    else va.rc - vb.rc;
 
   # To identify the latest available version we must sorted all versions
   # in descending order and then take the first element

--- a/lib/mk-tool-set.nix
+++ b/lib/mk-tool-set.nix
@@ -7,44 +7,11 @@
   buildGoTool,
   toolManifests,
 }: let
-  # Parse a Go version string into comparable components.
-  # Handles "1.22.0", "1.18", and "1.25rc1" formats.
-  parseGoVersion = v: let
-    parts = lib.splitString "." v;
-    major = lib.toInt (builtins.elemAt parts 0);
-    minorPart = builtins.elemAt parts 1;
-    hasRc = builtins.match "([0-9]+)rc([0-9]+)" minorPart;
-  in
-    if hasRc != null
-    then {
-      inherit major;
-      minor = lib.toInt (builtins.elemAt hasRc 0);
-      patch = 0;
-      rc = lib.toInt (builtins.elemAt hasRc 1);
-    }
-    else {
-      inherit major;
-      minor = lib.toInt minorPart;
-      patch =
-        if builtins.length parts > 2
-        then lib.toInt (builtins.elemAt parts 2)
-        else 0;
-      # Stable releases sort after all RCs
-      rc = 999999;
-    };
+  inherit (import ./version.nix {inherit lib;}) compareVersions;
 
   # Returns true if goVersion >= requiredVersion
-  isGoCompatible = goVersion: requiredVersion: let
-    go = parseGoVersion goVersion;
-    req = parseGoVersion requiredVersion;
-  in
-    if go.major != req.major
-    then go.major > req.major
-    else if go.minor != req.minor
-    then go.minor > req.minor
-    else if go.patch != req.patch
-    then go.patch > req.patch
-    else go.rc >= req.rc;
+  isGoCompatible = goVersion: requiredVersion:
+    compareVersions goVersion requiredVersion >= 0;
 in
   # go: the Go toolchain derivation (has .version attribute)
   go: let

--- a/lib/version.nix
+++ b/lib/version.nix
@@ -1,0 +1,49 @@
+{lib}: let
+  # Parse a Go version string into comparable components.
+  # Handles "1.22.0", "1.18", and "1.25rc1" formats.
+  #
+  # RC encoding: stable -> rc = 0; rcN -> rc = -1000 + N
+  # This keeps all RCs strictly below zero and stable at zero, so the same
+  # numeric comparison works for both sorting (compareVersions) and
+  # compatibility checks (>= 0 means "at least as new as required").
+  parseVersion = v: let
+    parts = lib.splitString "." v;
+    major = lib.toInt (builtins.elemAt parts 0);
+    minorPart = builtins.elemAt parts 1;
+    hasRc = builtins.match "([0-9]+)rc([0-9]+)" minorPart;
+  in
+    if builtins.length parts < 2 || builtins.length parts > 3
+    then throw "go-overlay: invalid Go version '${v}' (expected major.minor[.patch][rcN])"
+    else if hasRc != null
+    then {
+      inherit major;
+      minor = lib.toInt (builtins.elemAt hasRc 0);
+      patch = 0;
+      rc = -1000 + lib.toInt (builtins.elemAt hasRc 1);
+    }
+    else {
+      inherit major;
+      minor = lib.toInt minorPart;
+      patch =
+        if builtins.length parts > 2
+        then lib.toInt (builtins.elemAt parts 2)
+        else 0;
+      rc = 0;
+    };
+
+  # Compare two version strings; returns a positive int if a > b, negative if
+  # a < b, and zero if equal.
+  compareVersions = a: b: let
+    va = parseVersion a;
+    vb = parseVersion b;
+  in
+    if va.major != vb.major
+    then va.major - vb.major
+    else if va.minor != vb.minor
+    then va.minor - vb.minor
+    else if va.patch != vb.patch
+    then va.patch - vb.patch
+    else va.rc - vb.rc;
+in {
+  inherit parseVersion compareVersions;
+}


### PR DESCRIPTION
closes #495

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated version parsing and comparison into a shared utility, improving consistency across manifest version selection (including latest/latestStable and deprecated/version lists) and Go tool compatibility checks.
  * Existing behavior and output remain the same, but version ordering and stability/RC handling are now driven by the shared comparison logic for more reliable results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->