### PR TITLE
test: validate #505 govendor-update fix (disposable, do not merge)

### DIFF
--- a/.github/workflows/govendor-update.yml
+++ b/.github/workflows/govendor-update.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     inputs:
       working-directory:
-        description: "Working directory for govendor manifest generation"
+        description: "Working directory (or newline-separated list of directories) for govendor manifest generation"
         required: false
         type: string
         default: "."
@@ -45,13 +45,24 @@ jobs:
           passphrase: ${{ secrets.gpg-passphrase }}
 
       - name: Update govendor.toml
-        working-directory: ${{ inputs.working-directory }}
         env:
           CO_AUTHOR: ${{ inputs.co-author }}
+          DIRS: ${{ inputs.working-directory }}
         run: |
-          nix run github:purpleclay/go-overlay#govendor
+          changed=0
+          while IFS= read -r dir; do
+            [ -z "$dir" ] && continue
+            echo "::group::govendor ($dir)"
+            (cd "$dir" && nix run github:purpleclay/go-overlay#govendor)
+            echo "::endgroup::"
 
-          if git diff --quiet govendor.toml; then
+            if ! git diff --quiet -- "$dir/govendor.toml"; then
+              git add "$dir/govendor.toml"
+              changed=1
+            fi
+          done <<< "$DIRS"
+
+          if [ "$changed" -eq 0 ]; then
             echo "No changes to govendor.toml"
             exit 0
           fi
@@ -60,6 +71,5 @@ jobs:
             CO_AUTHOR="$(git config user.name) <$(git config user.email)>"
           fi
 
-          git add govendor.toml
           git commit --amend --no-edit --trailer "Co-authored-by: $CO_AUTHOR"
           git push --force-with-lease

--- a/.github/workflows/govendor-update.yml
+++ b/.github/workflows/govendor-update.yml
@@ -53,7 +53,10 @@ jobs:
           while IFS= read -r dir; do
             [ -z "$dir" ] && continue
             echo "::group::govendor ($dir)"
-            (cd "$dir" && nix run github:purpleclay/go-overlay#govendor)
+            (cd "$dir" && nix run github:purpleclay/go-overlay#govendor) || {
+              echo "::error::govendor failed for $dir"
+              exit 1
+            }
             echo "::endgroup::"
 
             if ! git diff --quiet -- "$dir/govendor.toml"; then

--- a/.github/workflows/vendor.yml
+++ b/.github/workflows/vendor.yml
@@ -24,7 +24,7 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           dirs=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" \
-            | grep -E '(^|/)go\.(mod|sum)$' \
+            | awk '/(^|\/)go\.(mod|sum)$/{print}' \
             | xargs -r -n1 dirname | sort -u)
 
           {

--- a/.github/workflows/vendor.yml
+++ b/.github/workflows/vendor.yml
@@ -8,6 +8,8 @@ jobs:
   detect:
     if: startsWith(github.head_ref, 'renovate/')
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     outputs:
       dirs: ${{ steps.detect.outputs.dirs }}
     steps:
@@ -36,6 +38,8 @@ jobs:
   vendor:
     needs: detect
     if: needs.detect.outputs.dirs != ''
+    permissions:
+      contents: read
     uses: purpleclay/go-overlay/.github/workflows/govendor-update.yml@renovate/test-505-govendor-fix
     with:
       working-directory: ${{ needs.detect.outputs.dirs }}

--- a/.github/workflows/vendor.yml
+++ b/.github/workflows/vendor.yml
@@ -15,11 +15,15 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Detect changed module directories
         id: detect
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          dirs=$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}" \
+          dirs=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" \
             | grep -E '(^|/)go\.(mod|sum)$' \
             | xargs -r -n1 dirname | sort -u)
 

--- a/.github/workflows/vendor.yml
+++ b/.github/workflows/vendor.yml
@@ -5,9 +5,36 @@ on:
     paths: ["**/go.mod", "**/go.sum"]
 
 jobs:
-  vendor:
+  detect:
     if: startsWith(github.head_ref, 'renovate/')
-    uses: purpleclay/go-overlay/.github/workflows/govendor-update.yml@main
+    runs-on: ubuntu-24.04
+    outputs:
+      dirs: ${{ steps.detect.outputs.dirs }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed module directories
+        id: detect
+        run: |
+          dirs=$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}" \
+            | grep -E '(^|/)go\.(mod|sum)$' \
+            | xargs -r -n1 dirname | sort -u)
+
+          {
+            echo "dirs<<EOF"
+            echo "$dirs"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+  vendor:
+    needs: detect
+    if: needs.detect.outputs.dirs != ''
+    uses: purpleclay/go-overlay/.github/workflows/govendor-update.yml@renovate/test-505-govendor-fix
+    with:
+      working-directory: ${{ needs.detect.outputs.dirs }}
     secrets:
       token: ${{ secrets.GH_NSV }}
       gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}

--- a/templates/image/go.mod
+++ b/templates/image/go.mod
@@ -2,4 +2,4 @@ module example
 
 go 1.26.3
 
-require github.com/go-chi/chi/v5 v5.2.5
+require github.com/go-chi/chi/v5 v5.3.0

--- a/templates/image/go.sum
+++ b/templates/image/go.sum
@@ -1,4 +1,2 @@
-github.com/go-chi/chi/v5 v5.2.2 h1:CMwsvRVTbXVytCk1Wd72Zy1LAsAh9GxMmSNWLHCG618=
-github.com/go-chi/chi/v5 v5.2.2/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
-github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
-github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=
+github.com/go-chi/chi/v5 v5.3.0 h1:halUjDxhshgXHMrao5bB8eNBXo/rnzwr8m5m36glehM=
+github.com/go-chi/chi/v5 v5.3.0/go.mod h1:R+tYY2hNuVUUjxoPtqUdgBqevM9s9njzkTLutVsOCto=

--- a/templates/image/govendor.toml
+++ b/templates/image/govendor.toml
@@ -4,7 +4,7 @@ schema = 3
 
 [mod]
   [mod."github.com/go-chi/chi/v5"]
-    version = "v5.2.5"
-    hash = "sha256-Y1+17ky94849aqk3iKf30F1u+G6K3nzZzLOBSeqIUow="
-    go = "1.22"
+    version = "v5.3.0"
+    hash = "sha256-ufvApHNHP7n7Hhcu1ocTl0D+KiMFd7y98Kx1IZ4aHXc="
+    go = "1.23"
     packages = ["github.com/go-chi/chi/v5", "github.com/go-chi/chi/v5/middleware"]


### PR DESCRIPTION
Disposable test PR to validate the #505 fix (Renovate updates on templates failing CI due to govendor.toml not updating).

Reproduces PR #474's exact `templates/image` bump (`github.com/go-chi/chi/v5` v5.2.5 → v5.3.0) on top of the fixed `vendor.yml`/`govendor-update.yml`. The reusable workflow ref is temporarily pinned to this branch instead of `@main` so the fix is actually exercised.

**Do not merge.** Will be closed and deleted once validated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Dependencies**
  * Updated go-chi/chi to v5.3.0

* **Chores**
  * Improved vendor management workflow to handle multiple directories and detect changes more efficiently
<!-- end of auto-generated comment: release notes by coderabbit.ai -->