### PR TITLE
fix(ci): vendor multiple changed go.mod directories on Renovate PRs

### DIFF
--- a/.github/workflows/govendor-update.yml
+++ b/.github/workflows/govendor-update.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     inputs:
       working-directory:
-        description: "Working directory for govendor manifest generation"
+        description: "Working directory (or newline-separated list of directories) for govendor manifest generation"
         required: false
         type: string
         default: "."
@@ -45,13 +45,23 @@ jobs:
           passphrase: ${{ secrets.gpg-passphrase }}
 
       - name: Update govendor.toml
-        working-directory: ${{ inputs.working-directory }}
         env:
           CO_AUTHOR: ${{ inputs.co-author }}
+          DIRS: ${{ inputs.working-directory }}
         run: |
-          nix run github:purpleclay/go-overlay#govendor
+          while IFS= read -r dir; do
+            [ -z "$dir" ] && continue
+            echo "::group::govendor ($dir)"
+            (cd "$dir" && nix run github:purpleclay/go-overlay#govendor) || {
+              echo "::error::govendor failed for $dir"
+              exit 1
+            }
+            echo "::endgroup::"
 
-          if git diff --quiet govendor.toml; then
+            git add "$dir/govendor.toml"
+          done <<< "$DIRS"
+
+          if git diff --cached --quiet; then
             echo "No changes to govendor.toml"
             exit 0
           fi
@@ -60,6 +70,5 @@ jobs:
             CO_AUTHOR="$(git config user.name) <$(git config user.email)>"
           fi
 
-          git add govendor.toml
           git commit --amend --no-edit --trailer "Co-authored-by: $CO_AUTHOR"
           git push --force-with-lease

--- a/.github/workflows/vendor.yml
+++ b/.github/workflows/vendor.yml
@@ -5,9 +5,44 @@ on:
     paths: ["**/go.mod", "**/go.sum"]
 
 jobs:
-  vendor:
+  detect:
     if: startsWith(github.head_ref, 'renovate/')
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      dirs: ${{ steps.detect.outputs.dirs }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Detect changed module directories
+        id: detect
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          dirs=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" \
+            | awk '/(^|\/)go\.(mod|sum)$/{print}' \
+            | xargs -r -n1 dirname | sort -u)
+
+          {
+            echo "dirs<<EOF"
+            echo "$dirs"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+  vendor:
+    needs: detect
+    if: needs.detect.outputs.dirs != ''
+    permissions:
+      contents: read
     uses: purpleclay/go-overlay/.github/workflows/govendor-update.yml@main
+    with:
+      working-directory: ${{ needs.detect.outputs.dirs }}
     secrets:
       token: ${{ secrets.GH_NSV }}
       gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}


### PR DESCRIPTION
closes #505

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the vendor update automation by detecting which Go module directories were affected and running the update only for those directories, reducing unnecessary work.
  * Updated the workflow logic to handle a set of directories consistently and to stage and commit only when changes are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->