### PR TITLE
fix(govendor): stop double-printing errors and route them to stderr

### DIFF
--- a/cmd/govendor/main.go
+++ b/cmd/govendor/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"runtime"
 
@@ -24,8 +23,9 @@ func main() {
 		Platform:  runtime.GOOS + "/" + runtime.GOARCH,
 	}
 
+	// cli.Execute already renders the error to stderr via the configured
+	// error handler before returning it here.
 	if err := govendor.Execute(version); err != nil {
-		fmt.Println(err.Error())
 		os.Exit(1)
 	}
 }

--- a/govendor.nix
+++ b/govendor.nix
@@ -5,8 +5,8 @@
   commit ? "unknown",
 }: let
   pname = "govendor";
-  version = "v1.0.1";
-  buildDate = "2026-06-11T00:00:00Z";
+  version = "v1.0.2";
+  buildDate = "2026-06-22T00:00:00Z";
 in
   buildGoApplication {
     inherit pname version go;

--- a/internal/cli/govendor/root.go
+++ b/internal/cli/govendor/root.go
@@ -1,7 +1,9 @@
 package govendor
 
 import (
+	"errors"
 	"fmt"
+	"io"
 
 	"github.com/purpleclay/go-overlay/internal/resolve"
 	"github.com/purpleclay/go-overlay/internal/ui"
@@ -18,6 +20,7 @@ func Execute(version cli.VersionInfo) error {
 		workspace        bool
 		depth            int
 		includePlatforms []string
+		tableRendered    bool
 	)
 
 	cmd := &cobra.Command{
@@ -98,6 +101,7 @@ func Execute(version cli.VersionInfo) error {
 			v := vendor.NewVendor(resolver, opts...)
 			results, err := v.VendorFiles(cmd.Context())
 			if len(results) > 0 {
+				tableRendered = true
 				fmt.Fprintln(cmd.OutOrStdout(), ui.RenderResultsTable(results))
 			}
 			return err
@@ -111,8 +115,17 @@ func Execute(version cli.VersionInfo) error {
 	cmd.Flags().StringArrayVar(&includePlatforms, "include-platform", nil, "extend platform list for dependency resolution (e.g., freebsd/amd64)")
 	cmd.MarkFlagsMutuallyExclusive("recursive", "workspace")
 
-	return cli.Execute(cmd,
+	return cli.Execute(
+		cmd,
 		cli.WithVersionFlag(version),
 		cli.WithTheme(theme.PurpleClayCLI()),
+		cli.WithErrorHandler(func(w io.Writer, t cli.Theme, err error) {
+			// The results table already reports per-result failures; printing
+			// the generic sentinel underneath it adds nothing new.
+			if tableRendered && errors.Is(err, vendor.ErrVendorFailed) {
+				return
+			}
+			cli.DefaultErrorHandler(w, t, err)
+		}),
 	)
 }

--- a/internal/vendor/vendor.go
+++ b/internal/vendor/vendor.go
@@ -84,7 +84,10 @@ func NewVendor(resolver Resolver, opts ...Option) *Vendor {
 	return v
 }
 
-var errVendorFailed = fmt.Errorf("vendor failed")
+// ErrVendorFailed indicates one or more results in the rendered table failed.
+// It carries no information beyond what the table already shows, so callers
+// that have rendered the results table may choose to suppress its message.
+var ErrVendorFailed = fmt.Errorf("vendor failed")
 
 // dependencySource is satisfied by *mod.GoModFile and *mod.GoWorkFile.
 // Type switches on this value are used to dispatch to type-specific behaviour.
@@ -134,7 +137,7 @@ func (v *Vendor) VendorFiles(ctx context.Context) ([]Result, error) {
 
 	for _, r := range results {
 		if r.Status.IsFailure() {
-			return results, errVendorFailed
+			return results, ErrVendorFailed
 		}
 	}
 
@@ -143,7 +146,7 @@ func (v *Vendor) VendorFiles(ctx context.Context) ([]Result, error) {
 
 func (v *Vendor) toResults(r Result) ([]Result, error) {
 	if r.Status.IsFailure() {
-		return []Result{r}, errVendorFailed
+		return []Result{r}, ErrVendorFailed
 	}
 	return []Result{r}, nil
 }


### PR DESCRIPTION
closes #511

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling to prevent duplicate error messages when per-result failures are already displayed to users.

* **Chores**
  * Version bumped to v1.0.2 with updated build metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->