### PR TITLE
fix(ci): fall back to direct merge when PR auto-merge is rejected

### DIFF
--- a/.github/workflows/tools-update.yml
+++ b/.github/workflows/tools-update.yml
@@ -130,4 +130,9 @@ jobs:
             --base main \
             --head "$branch"
 
-          gh pr merge --auto --squash "$branch"
+          # enablePullRequestAutoMerge only succeeds while something is still
+          # pending; if checks already completed by this point, the PR is
+          # already mergeable and --auto is rejected, so merge directly.
+          if ! gh pr merge --auto --squash "$branch"; then
+            gh pr merge --squash "$branch"
+          fi


### PR DESCRIPTION
closes #518

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of automated update pull requests by handling merge completion more gracefully when auto-merge is unavailable.
  * Reduced failed PR creation/merge attempts for generated tool updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->