### PR TITLE
ci: pin self-referential govendor-update.yml workflow ref to a commit SHA

### DIFF
--- a/.github/workflows/vendor.yml
+++ b/.github/workflows/vendor.yml
@@ -40,7 +40,7 @@ jobs:
     if: needs.detect.outputs.dirs != ''
     permissions:
       contents: read
-    uses: purpleclay/go-overlay/.github/workflows/govendor-update.yml@main
+    uses: purpleclay/go-overlay/.github/workflows/govendor-update.yml@d4dbfafe2569ca3e58c60b9f65993a872b6bee94 # main
     with:
       working-directory: ${{ needs.detect.outputs.dirs }}
     secrets:


### PR DESCRIPTION
closes #520

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated vendor workflow to use a fixed version, improving build stability and consistency over time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->