### PR TITLE
ci: use local govendor-update.yaml instead of pinning

### DIFF
--- a/.github/workflows/vendor.yml
+++ b/.github/workflows/vendor.yml
@@ -40,7 +40,7 @@ jobs:
     if: needs.detect.outputs.dirs != ''
     permissions:
       contents: read
-    uses: purpleclay/go-overlay/.github/workflows/govendor-update.yml@d4dbfafe2569ca3e58c60b9f65993a872b6bee94 # main
+    uses: ./.github/workflows/govendor-update.yml
     with:
       working-directory: ${{ needs.detect.outputs.dirs }}
     secrets:


### PR DESCRIPTION
closes https://github.com/purpleclay/go-overlay/issues/520

alternative to https://github.com/purpleclay/go-overlay/pull/521

pinning a local workflow to a commit would just lead to a perpetual Renovate update loop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the vendor workflow to use the repository’s local workflow file instead of an external pinned source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->