### PR TITLE
fix(govendor): write govendor.toml atomically to avoid truncation on interrupt

### DIFF
--- a/govendor.nix
+++ b/govendor.nix
@@ -5,8 +5,8 @@
   commit ? "unknown",
 }: let
   pname = "govendor";
-  version = "v1.1.0";
-  buildDate = "2026-06-23T00:00:00Z";
+  version = "v1.1.1";
+  buildDate = "2026-06-27T00:00:00Z";
 in
   buildGoApplication {
     inherit pname version go;

--- a/internal/vendor/vendor.go
+++ b/internal/vendor/vendor.go
@@ -206,7 +206,7 @@ func (v *Vendor) processSource(ctx context.Context, src dependencySource, displa
 		return resultOK(displayPath)
 	}
 
-	if err := os.WriteFile(vendorPath, newData, 0o644); err != nil {
+	if err := atomicWrite(vendorPath, newData); err != nil {
 		return resultError(displayPath, err)
 	}
 

--- a/internal/vendor/writer.go
+++ b/internal/vendor/writer.go
@@ -1,0 +1,47 @@
+package vendor
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// atomicWrite writes data to path by first writing to a temporary file in
+// the same directory, fsyncing it, then renaming it over path. The rename
+// is the only operation that touches path itself, so an interrupted
+// process (Ctrl+C, an OOM-killed CI job) can only ever leave behind an
+// orphaned temp file, never a truncated path.
+func atomicWrite(path string, data []byte) error {
+	dir := filepath.Dir(path)
+
+	tmp, err := os.CreateTemp(dir, ".govendor-*.toml")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath) // no-op once the rename below succeeds
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return fmt.Errorf("failed to write temp file: %w", err)
+	}
+
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return fmt.Errorf("failed to sync temp file: %w", err)
+	}
+
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("failed to close temp file: %w", err)
+	}
+
+	if err := os.Chmod(tmpPath, 0o644); err != nil {
+		return fmt.Errorf("failed to set temp file permissions: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("failed to rename temp file to %s: %w", path, err)
+	}
+
+	return nil
+}

--- a/internal/vendor/writer_test.go
+++ b/internal/vendor/writer_test.go
@@ -1,0 +1,42 @@
+package vendor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAtomicWriteLeavesNoOrphanedTempFile(t *testing.T) {
+	t.Run("OK", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, vendorFile)
+
+		require.NoError(t, atomicWrite(path, []byte("hello")))
+
+		got, err := os.ReadFile(path)
+		require.NoError(t, err)
+		assert.Equal(t, "hello", string(got))
+
+		entries, err := os.ReadDir(dir)
+		require.NoError(t, err)
+		require.Len(t, entries, 1)
+		assert.Equal(t, vendorFile, entries[0].Name())
+	})
+
+	t.Run("RenameFailure", func(t *testing.T) {
+		dir := t.TempDir()
+		// A directory at the target path makes the final rename fail.
+		path := filepath.Join(dir, vendorFile)
+		require.NoError(t, os.Mkdir(path, 0o755))
+
+		require.Error(t, atomicWrite(path, []byte("hello")))
+
+		entries, err := os.ReadDir(dir)
+		require.NoError(t, err)
+		require.Len(t, entries, 1, "temp file must be cleaned up after a rename failure")
+		assert.Equal(t, vendorFile, entries[0].Name())
+	})
+}


### PR DESCRIPTION
closes #509

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled dependency metadata to the latest patch release.
  * Refreshed the recorded build date for the dependency package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->