### PR TITLE
fix(builder): extract host tool src at build time to support any src form

### DIFF
--- a/.github/workflows/nix-checks.yml
+++ b/.github/workflows/nix-checks.yml
@@ -49,4 +49,6 @@ jobs:
           cachix-token: ${{ secrets.GH_CACHIX }}
 
       - name: Run all checks
-        run: nix run github:Mic92/nix-fast-build -- --skip-cached --no-nom --max-jobs 2 --flake .#checks
+        run: |
+          system=$(nix eval --impure --raw --expr 'builtins.currentSystem')
+          nix run github:Mic92/nix-fast-build -- --skip-cached --no-nom --max-jobs 2 --flake ".#checks.${system}"

--- a/builder/default.nix
+++ b/builder/default.nix
@@ -22,7 +22,7 @@
   vendorEnvModule = import ./vendor-env.nix {inherit lib runCommand fetchGoModule;};
   inherit (vendorEnvModule) mkVendorEnv mkModuleCopyCommands;
 
-  hostToolModule = import ./host-tool.nix {inherit lib stdenv;};
+  hostToolModule = import ./host-tool.nix {inherit lib stdenv runCommand;};
   inherit (hostToolModule) mkHostTool parseGoWorkModules;
 
   commonModule = import ./common.nix {inherit lib;};

--- a/builder/host-tool.nix
+++ b/builder/host-tool.nix
@@ -7,8 +7,9 @@
 {
   lib,
   stdenv,
+  runCommand,
 }: let
-  inherit (lib) escapeShellArg optionalString splitString;
+  inherit (lib) concatMapStringsSep escapeShellArg optionalString splitString;
 in {
   # Parse workspace member paths from a go.work file's content.
   # Handles both single-line (use ./path) and block (use (\n  ./path\n)) forms.
@@ -55,24 +56,44 @@ in {
     members ? [], # workspace member paths (relative to src); [] for a single module
   }: let
     # go install builds entirely from go.mod/go.sum + vendor/ in -mod=vendor
-    # mode — it never touches the application's .go sources. Restricting src
-    # to just those files means editing application code doesn't change this
-    # derivation's input hash, so the tool only rebuilds when the dependency
-    # graph (go.mod/go.sum) actually changes.
-    toolSrc = lib.fileset.toSource {
-      root = src;
-      fileset = lib.fileset.unions (
-        [
-          (lib.fileset.maybeMissing (src + "/go.mod"))
-          (lib.fileset.maybeMissing (src + "/go.sum"))
-        ]
-        ++ lib.concatMap (m: [
-          (lib.fileset.maybeMissing (src + "/${m}/go.mod"))
-          (lib.fileset.maybeMissing (src + "/${m}/go.sum"))
-        ])
-        members
-      );
-    };
+    # mode — it never touches the application's .go sources. Restricting
+    # toolSrc to just those files means editing application code doesn't
+    # change this derivation's input hash, so the tool only rebuilds when
+    # the dependency graph (go.mod/go.sum) actually changes.
+    #
+    # Each file's *content* is read at evaluation time — via readFile/
+    # pathExists, which transparently realise whatever src resolves to,
+    # whether that's a literal path, a derivation, or an already-filtered
+    # lib.fileset/lib.sources value — then re-wrapped with builtins.toFile,
+    # a store path that's a pure function of the file's bytes alone.
+    # toolSrc's own inputs are therefore these toFile paths, never src
+    # itself, so its hash never changes just because some unrelated part of
+    # src did, for any form src takes (go-overlay#531).
+    goModPaths = ["go.mod" "go.sum"] ++ lib.concatMap (m: ["${m}/go.mod" "${m}/go.sum"]) members;
+
+    toolFiles = builtins.filter (f: f != null) (
+      map (
+        p: let
+          fullPath = src + "/${p}";
+        in
+          if builtins.pathExists fullPath
+          then {
+            path = p;
+            file = builtins.toFile (baseNameOf p) (builtins.readFile fullPath);
+          }
+          else null
+      )
+      goModPaths
+    );
+
+    toolSrc = runCommand "${baseNameOf pkg}-tool-src" {} (
+      "mkdir -p $out\n"
+      + concatMapStringsSep "\n" (f: ''
+        mkdir -p "$out/$(dirname ${escapeShellArg f.path})"
+        cp ${f.file} "$out/${f.path}"
+      '')
+      toolFiles
+    );
   in
     stdenv.mkDerivation {
       pname = baseNameOf pkg;

--- a/examples/go-workspace-inferred/README.md
+++ b/examples/go-workspace-inferred/README.md
@@ -15,6 +15,10 @@ Then open [http://localhost:8080](http://localhost:8080) in your browser.
 ## The Nix bit
 
 ```nix
+{
+  pkgs,
+  go,
+}:
 # There is no go.work in this source tree — buildGoWorkspace infers the workspace
 # structure from the govendor.toml manifest and generates go.work at build time.
 pkgs.buildGoWorkspace {

--- a/examples/go-workspace-vendored/README.md
+++ b/examples/go-workspace-vendored/README.md
@@ -15,6 +15,10 @@ Then open [http://localhost:8080](http://localhost:8080) in your browser.
 ## The Nix bit
 
 ```nix
+{
+  pkgs,
+  go,
+}:
 # No govendor.toml — buildGoVendoredWorkspace uses the committed vendor/ directory directly.
 pkgs.buildGoVendoredWorkspace {
   inherit go;

--- a/examples/go-workspace/README.md
+++ b/examples/go-workspace/README.md
@@ -15,6 +15,10 @@ Then open [http://localhost:8080](http://localhost:8080) in your browser.
 ## The Nix bit
 
 ```nix
+{
+  pkgs,
+  go,
+}:
 pkgs.buildGoWorkspace {
   inherit go;
 

--- a/examples/http-chi-server/README.md
+++ b/examples/http-chi-server/README.md
@@ -20,6 +20,10 @@ curl http://localhost:8080/name
 ## The Nix bit
 
 ```nix
+{
+  pkgs,
+  go,
+}:
 pkgs.buildGoApplication {
   inherit go;
 

--- a/examples/local-replaces/README.md
+++ b/examples/local-replaces/README.md
@@ -19,9 +19,12 @@ nix run .#example-local-replaces
 ## The Nix bit
 
 ```nix
+{
+  pkgs,
+  go,
+}:
 pkgs.buildGoApplication {
   inherit go;
-
   pname = "local-replaces";
   version = "0.1.0";
   src = ./.;

--- a/examples/oapi-codegen/README.md
+++ b/examples/oapi-codegen/README.md
@@ -15,20 +15,39 @@ Then open [http://localhost:8080](http://localhost:8080) in your browser.
 ## The Nix bit
 
 ```nix
-pkgs.buildGoApplication {
-  inherit go;
+{
+  pkgs,
+  go,
+}: let
+  inherit (pkgs) lib;
+in
+  pkgs.buildGoApplication {
+    inherit go;
 
-  pname = "oapi-codegen";
-  version = "0.1.0";
-  src = ./.;
+    pname = "oapi-codegen";
+    version = "0.1.0";
 
-  # oapi-codegen is declared as a tool directive in go.mod. govendor compiles
-  # it for the host platform and injects the binary into nativeBuildInputs,
-  # making it available in $PATH here without any extra configuration.
-  preBuild = ''
-    oapi-codegen --config=api/oapi-codegen.yaml api/catto.yaml
-  '';
-}
+    # Pre-filtering src with lib.fileset is the recommended way to keep docs
+    # and other non-build files from busting your application's build cache
+    # — the same principle go-overlay applies internally to decouple the
+    # host tool's own build from your application source.
+    src = lib.fileset.toSource {
+      root = ./.;
+      fileset = lib.fileset.difference ./. (
+        lib.fileset.unions [
+          ./README.md
+          ./.gitignore
+        ]
+      );
+    };
+
+    # oapi-codegen is declared as a tool directive in go.mod. govendor compiles
+    # it for the host platform and injects the binary into nativeBuildInputs,
+    # making it available in $PATH here without any extra configuration.
+    preBuild = ''
+      oapi-codegen --config=api/oapi-codegen.yaml api/catto.yaml
+    '';
+  }
 ```
 
 The tool is invoked by its binary name directly — no `go generate`, no `go tool`. Because govendor compiles the tool for the **host** platform and injects it into `nativeBuildInputs`, this works correctly under cross-compilation without any workarounds.

--- a/examples/oapi-codegen/default.nix
+++ b/examples/oapi-codegen/default.nix
@@ -1,18 +1,33 @@
 {
   pkgs,
   go,
-}:
-pkgs.buildGoApplication {
-  inherit go;
+}: let
+  inherit (pkgs) lib;
+in
+  pkgs.buildGoApplication {
+    inherit go;
 
-  pname = "oapi-codegen";
-  version = "0.1.0";
-  src = ./.;
+    pname = "oapi-codegen";
+    version = "0.1.0";
 
-  # oapi-codegen is declared as a tool directive in go.mod. govendor compiles
-  # it for the host platform and injects the binary into nativeBuildInputs,
-  # making it available in $PATH here without any extra configuration.
-  preBuild = ''
-    oapi-codegen --config=api/oapi-codegen.yaml api/catto.yaml
-  '';
-}
+    # Pre-filtering src with lib.fileset is the recommended way to keep docs
+    # and other non-build files from busting your application's build cache
+    # — the same principle go-overlay applies internally to decouple the
+    # host tool's own build from your application source.
+    src = lib.fileset.toSource {
+      root = ./.;
+      fileset = lib.fileset.difference ./. (
+        lib.fileset.unions [
+          ./README.md
+          ./.gitignore
+        ]
+      );
+    };
+
+    # oapi-codegen is declared as a tool directive in go.mod. govendor compiles
+    # it for the host platform and injects the binary into nativeBuildInputs,
+    # making it available in $PATH here without any extra configuration.
+    preBuild = ''
+      oapi-codegen --config=api/oapi-codegen.yaml api/catto.yaml
+    '';
+  }

--- a/examples/sqlc-codegen/README.md
+++ b/examples/sqlc-codegen/README.md
@@ -19,6 +19,10 @@ Available categories: `build`, `tests`, `deploy`, `review`, `meeting`.
 ## The Nix bit
 
 ```nix
+{
+  pkgs,
+  go,
+}:
 pkgs.buildGoApplication {
   inherit go;
 

--- a/test/default.nix
+++ b/test/default.nix
@@ -80,6 +80,19 @@
   in
     assertEq name (map (_: expected) drv.hostTools) actual;
 
+  # Asserts a host tool's drvPath is identical for two src values that
+  # differ only in files outside go.mod/go.sum. This is the property that
+  # actually matters for avoiding host tool rebuilds — assertHostToolSrcIsMinimal
+  # checks the resulting file set is correct, but doesn't catch a toolSrc
+  # construction that still embeds the full src as a derivation input
+  # (which keeps the file set minimal yet still busts the store path on
+  # every unrelated change — exactly the regression this guards against).
+  assertHostToolDrvPathStable = name: mkDrv: srcA: srcB: let
+    toolA = builtins.head (mkDrv srcA).hostTools;
+    toolB = builtins.head (mkDrv srcB).hostTools;
+  in
+    assertEq name toolA.drvPath toolB.drvPath;
+
   # Evaluates the shell expression produced by mkTestPackages and asserts its
   # output matches expected.
   testTestPackages = name: {
@@ -284,4 +297,63 @@ in {
     };
   in
     assertHostToolSrcIsMinimal "hostTool-workspace-src-is-minimal" drv ["app/go.mod" "app/go.sum"];
+
+  # A caller may pass an already-filtered src (e.g. their own
+  # lib.fileset.toSource call) rather than a raw path. The minimal-src
+  # extraction happens at build time precisely so it isn't limited to
+  # literal paths, so this must still produce a minimal src, not just avoid
+  # crashing (go-overlay#531).
+  hostTool-application-non-path-src-is-minimal = let
+    rawSrc = ./fixtures/host-tool-app;
+    filteredSrc = pkgs.lib.fileset.toSource {
+      root = rawSrc;
+      fileset = pkgs.lib.fileset.fromSource (pkgs.lib.sources.cleanSource rawSrc);
+    };
+    drv = pkgs.buildGoApplication {
+      pname = "host-tool-app";
+      version = "0.1.0";
+      src = filteredSrc;
+      go = go-bin.fromGoMod (rawSrc + "/go.mod");
+    };
+  in
+    assertHostToolSrcIsMinimal "hostTool-application-non-path-src-is-minimal" drv ["go.mod" "go.sum"];
+
+  hostTool-application-drvpath-stable-across-unrelated-changes = let
+    baseSrc = ./fixtures/host-tool-app;
+    touchedSrc =
+      pkgs.runCommand "host-tool-app-touched" {}
+      ''
+        cp -r ${baseSrc} $out
+        chmod -R u+w $out
+        echo "// unrelated change" >> $out/main.go
+      '';
+    mkDrv = src:
+      pkgs.buildGoApplication {
+        pname = "host-tool-app";
+        version = "0.1.0";
+        inherit src;
+        go = go-bin.fromGoMod (baseSrc + "/go.mod");
+      };
+  in
+    assertHostToolDrvPathStable "hostTool-application-drvpath-stable-across-unrelated-changes" mkDrv baseSrc touchedSrc;
+
+  hostTool-workspace-drvpath-stable-across-unrelated-changes = let
+    baseSrc = ./fixtures/host-tool-workspace;
+    touchedSrc =
+      pkgs.runCommand "host-tool-workspace-touched" {}
+      ''
+        cp -r ${baseSrc} $out
+        chmod -R u+w $out
+        echo "// unrelated change" >> $out/app/main.go
+      '';
+    mkDrv = src:
+      pkgs.buildGoWorkspace {
+        pname = "host-tool-workspace";
+        version = "0.1.0";
+        inherit src;
+        subPackages = ["app"];
+        go = go-bin.fromGoMod (baseSrc + "/app/go.mod");
+      };
+  in
+    assertHostToolDrvPathStable "hostTool-workspace-drvpath-stable-across-unrelated-changes" mkDrv baseSrc touchedSrc;
 }


### PR DESCRIPTION
closes #531

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Go host-tool handling so only required `go.mod`/`go.sum` files are included, reducing unnecessary rebuilds and cache invalidation.
  * Strengthened host-tool stability so outputs don’t change when unrelated sources are modified.
* **Documentation**
  * Updated Nix snippets in multiple example READMEs to explicitly declare `{ pkgs, go }` inputs.
  * Refined the `oapi-codegen` example to use a cache-friendlier, filtered `src`.
* **Tests**
  * Added regression coverage for minimal host-tool inputs and stable derivation paths for both applications and workspaces.
* **Chores**
  * Improved Nix checks workflow to run with the current system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->