### PR TITLE
ci: use `nix flake check` instead of `Mic92/nix-fast-build`

### DIFF
--- a/.github/workflows/nix-checks.yml
+++ b/.github/workflows/nix-checks.yml
@@ -49,6 +49,4 @@ jobs:
           cachix-token: ${{ secrets.GH_CACHIX }}
 
       - name: Run all checks
-        run: |
-          system=$(nix eval --impure --raw --expr 'builtins.currentSystem')
-          nix run github:Mic92/nix-fast-build -- --skip-cached --no-nom --max-jobs 2 --flake ".#checks.${system}"
+        run: nix flake check


### PR DESCRIPTION
closes #533 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated Nix validation step to use a simpler check command.
  * Streamlined the workflow execution for more consistent and maintainable CI runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->