### PR TITLE
perf(govendor): reuse hashes and go versions from existing manifest

### DIFF
--- a/internal/cli/goscrape/modproxy/generate.go
+++ b/internal/cli/goscrape/modproxy/generate.go
@@ -185,7 +185,7 @@ func generateManifest(ctx context.Context, module, ver string, subPackages []str
 	// downloaded module source contains an in-tree vendor directory; without
 	// it, go list fails with incomplete vendored dependencies.
 	resolver := resolve.New(modEnvExecutor{baseEnv: []string{"GOFLAGS=-mod=mod"}})
-	deps, err := resolver.ResolveModule(ctx, goModFile, nixPlatforms)
+	deps, err := resolver.ResolveModule(ctx, goModFile, nixPlatforms, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/resolve/hash.go
+++ b/internal/resolve/hash.go
@@ -10,6 +10,18 @@ import (
 	"github.com/nix-community/go-nix/pkg/nar"
 )
 
+// Hasher computes the NAR hash of a directory. The interface allows tests to
+// inject a counting or deterministic implementation without hitting the real
+// filesystem hasher.
+type Hasher interface {
+	Hash(dir string) (string, error)
+}
+
+// NARHasher is the default Hasher that delegates to NARHash.
+type NARHasher struct{}
+
+func (NARHasher) Hash(dir string) (string, error) { return NARHash(dir) }
+
 // NARHash computes the NAR hash of a directory in SRI format.
 func NARHash(dir string) (string, error) {
 	h := sha256.New()

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -20,12 +20,13 @@ import (
 // commands go through the Executor interface, making the resolver testable
 // with injected output.
 type Resolver struct {
-	exec Executor
+	exec   Executor
+	hasher Hasher
 }
 
 // New creates a Resolver with the given executor.
 func New(exec Executor) *Resolver {
-	return &Resolver{exec: exec}
+	return &Resolver{exec: exec, hasher: NARHasher{}}
 }
 
 // ValidatePlatforms checks that all given platform strings are supported by
@@ -62,7 +63,8 @@ func (r *Resolver) ValidatePlatforms(ctx context.Context, platforms []string) er
 }
 
 // ResolveModule resolves all dependencies for a single Go module.
-func (r *Resolver) ResolveModule(ctx context.Context, goMod *mod.GoModFile, platforms []string) ([]mod.ModuleConfig, error) {
+// existingMods is the parsed existing manifest's module map; pass nil for a cold run.
+func (r *Resolver) ResolveModule(ctx context.Context, goMod *mod.GoModFile, platforms []string, existingMods map[string]mod.ModuleConfig) ([]mod.ModuleConfig, error) {
 	if platforms == nil {
 		platforms = mod.DefaultPlatforms()
 	}
@@ -77,7 +79,7 @@ func (r *Resolver) ResolveModule(ctx context.Context, goMod *mod.GoModFile, plat
 		return nil, err
 	}
 
-	modules, err := r.resolveRemoteModules(ctx, goMod.RemoteReplacements(), downloads, pkgsByMod)
+	modules, err := r.resolveRemoteModules(ctx, goMod.RemoteReplacements(), downloads, pkgsByMod, existingMods)
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +100,8 @@ func (r *Resolver) ResolveModule(ctx context.Context, goMod *mod.GoModFile, plat
 // ResolveWorkspace resolves dependencies across all modules in a Go workspace.
 // It runs a single go mod download from the workspace root so Go's MVS applies
 // across all members, then gathers per-member package attribution with GOWORK=off.
-func (r *Resolver) ResolveWorkspace(ctx context.Context, goWork *mod.GoWorkFile, platforms []string) ([]mod.ModuleConfig, error) {
+// existingMods is the parsed existing manifest's module map; pass nil for a cold run.
+func (r *Resolver) ResolveWorkspace(ctx context.Context, goWork *mod.GoWorkFile, platforms []string, existingMods map[string]mod.ModuleConfig) ([]mod.ModuleConfig, error) {
 	if platforms == nil {
 		platforms = mod.DefaultPlatforms()
 	}
@@ -148,7 +151,7 @@ func (r *Resolver) ResolveWorkspace(ctx context.Context, goWork *mod.GoWorkFile,
 	}
 	maps.Copy(remoteRepls, goWork.RemoteReplacements())
 
-	remoteDeps, err := r.resolveRemoteModules(ctx, remoteRepls, downloads, pkgsByMod)
+	remoteDeps, err := r.resolveRemoteModules(ctx, remoteRepls, downloads, pkgsByMod, existingMods)
 	if err != nil {
 		return nil, err
 	}
@@ -399,31 +402,66 @@ func (r *Resolver) downloadWorkspaceModules(ctx context.Context, goWork *mod.GoW
 	return ParseDownloadOutput(out)
 }
 
-func (r *Resolver) resolveRemoteModules(ctx context.Context, remoteReplacements map[string]mod.Replacement, downloads []ModuleDownload, pkgsByMod map[string][]string) ([]mod.ModuleConfig, error) {
+// goVersionFromMod best-effort reads the go directive from a downloaded
+// module's go.mod. Returns "" when the path is empty, unreadable, or unparsable.
+func goVersionFromMod(goModPath string) string {
+	if goModPath == "" {
+		return ""
+	}
+	data, err := os.ReadFile(goModPath)
+	if err != nil {
+		return ""
+	}
+	mf, err := modfile.Parse(goModPath, data, nil)
+	if err != nil || mf.Go == nil {
+		return ""
+	}
+	return mf.Go.Version
+}
+
+func (r *Resolver) resolveRemoteModules(ctx context.Context, remoteReplacements map[string]mod.Replacement, downloads []ModuleDownload, pkgsByMod map[string][]string, existingMods map[string]mod.ModuleConfig) ([]mod.ModuleConfig, error) {
 	p := pool.NewWithResults[mod.ModuleConfig]().WithMaxGoroutines(8).WithContext(ctx)
 
 	for _, meta := range downloads {
 		p.Go(func(_ context.Context) (mod.ModuleConfig, error) {
-			hash, err := NARHash(meta.Dir)
-			if err != nil {
-				return mod.ModuleConfig{}, fmt.Errorf("failed to hash downloaded module %s@%s: %w", meta.Path, meta.Version, err)
-			}
-
-			var goVersion string
-			if meta.GoMod != "" {
-				if modData, err := os.ReadFile(meta.GoMod); err == nil {
-					if mf, err := modfile.Parse(meta.GoMod, modData, nil); err == nil && mf.Go != nil {
-						goVersion = mf.Go.Version
-					}
-				}
-			}
-
+			// Determine the manifest key and replacement path before any I/O.
 			path := meta.Path
 			var replacedPath string
 			if repl, ok := remoteReplacements[path]; ok {
 				path = repl.OldPath
 				replacedPath = meta.Path
 			}
+
+			// Remote (path, version) pairs are immutable under the checksum DB.
+			// Reuse hash and go version from the existing manifest when the
+			// (path, version, replacedPath) triple matches and the entry is remote.
+			if existingMods != nil {
+				if entry, ok := existingMods[path]; ok &&
+					entry.Version == meta.Version &&
+					entry.Local == "" &&
+					entry.Hash != "" &&
+					entry.ReplacedPath == replacedPath {
+					goVersion := entry.GoVersion
+					if goVersion == "" {
+						goVersion = goVersionFromMod(meta.GoMod)
+					}
+					return mod.ModuleConfig{
+						Path:         path,
+						Version:      meta.Version,
+						Packages:     pkgsByMod[path],
+						Hash:         entry.Hash,
+						GoVersion:    goVersion,
+						ReplacedPath: replacedPath,
+					}, nil
+				}
+			}
+
+			hash, err := r.hasher.Hash(meta.Dir)
+			if err != nil {
+				return mod.ModuleConfig{}, fmt.Errorf("failed to hash downloaded module %s@%s: %w", meta.Path, meta.Version, err)
+			}
+
+			goVersion := goVersionFromMod(meta.GoMod)
 
 			return mod.ModuleConfig{
 				Path:         path,

--- a/internal/resolve/resolve_test.go
+++ b/internal/resolve/resolve_test.go
@@ -6,12 +6,29 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/purpleclay/go-overlay/internal/mod"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// countingHasher counts Hash calls and returns a fixed or per-dir hash.
+// Safe for concurrent use by the goroutine pool in resolveRemoteModules.
+type countingHasher struct {
+	count atomic.Int64
+	// returned for every call; defaults to "sha256-"+dir
+	hash string
+}
+
+func (h *countingHasher) Hash(dir string) (string, error) {
+	h.count.Add(1)
+	if h.hash != "" {
+		return h.hash, nil
+	}
+	return "sha256-" + dir, nil
+}
 
 // fakeExecutor returns canned responses keyed by either the full command
 // string or the first two args (e.g. "go list", "go mod", "git ls-files").
@@ -101,7 +118,7 @@ github.com/mattn/go-isatty	github.com/mattn/go-isatty`,
 	}
 
 	r := New(exec)
-	deps, err := r.ResolveModule(context.Background(), goMod, nil)
+	deps, err := r.ResolveModule(context.Background(), goMod, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, deps, 3)
 
@@ -147,7 +164,7 @@ replace example.com/localmod => ./localmod
 	}
 
 	r := New(exec)
-	deps, err := r.ResolveModule(context.Background(), goMod, nil)
+	deps, err := r.ResolveModule(context.Background(), goMod, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, deps, 1)
 
@@ -185,7 +202,7 @@ replace gopkg.in/ini.v1 => github.com/go-ini/ini v1.67.0
 	}
 
 	r := New(exec)
-	deps, err := r.ResolveModule(context.Background(), goMod, nil)
+	deps, err := r.ResolveModule(context.Background(), goMod, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, deps, 1)
 
@@ -244,7 +261,7 @@ github.com/mattn/go-isatty	github.com/mattn/go-isatty`,
 	}
 
 	r := New(exec)
-	deps, err := r.ResolveWorkspace(context.Background(), goWork, nil)
+	deps, err := r.ResolveWorkspace(context.Background(), goWork, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, deps, 3)
 
@@ -289,11 +306,191 @@ go 1.25.4
 	}
 
 	r := New(exec)
-	deps, err := r.ResolveWorkspace(context.Background(), goWork, nil)
+	deps, err := r.ResolveWorkspace(context.Background(), goWork, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, deps, 1)
 
 	assert.Equal(t, "github.com/purpleclay/example/core", deps[0].Path)
 	assert.Empty(t, deps[0].Hash)
 	assert.Empty(t, deps[0].Packages)
+}
+
+func TestResolveRemoteModulesHashReuse(t *testing.T) {
+	fooDownload := ModuleDownload{Path: "example.com/foo", Version: "v1.2.3", Dir: "/cache/foo"}
+	barDownload := ModuleDownload{Path: "example.com/bar", Version: "v2.0.0", Dir: "/cache/bar"}
+
+	fooExisting := mod.ModuleConfig{
+		Path:      "example.com/foo",
+		Version:   "v1.2.3",
+		Hash:      "sha256-cached-foo",
+		GoVersion: "1.22",
+	}
+	barExisting := mod.ModuleConfig{
+		Path:      "example.com/bar",
+		Version:   "v2.0.0",
+		Hash:      "sha256-cached-bar",
+		GoVersion: "1.23",
+	}
+
+	tests := []struct {
+		name          string
+		downloads     []ModuleDownload
+		existingMods  map[string]mod.ModuleConfig
+		remoteRepls   map[string]mod.Replacement // nil → derived from existingMods
+		wantHashCalls int64
+		wantHash      string
+		wantGoVersion string
+	}{
+		{
+			name:          "ReusesHashWhenVersionMatches",
+			downloads:     []ModuleDownload{fooDownload},
+			existingMods:  map[string]mod.ModuleConfig{"example.com/foo": fooExisting},
+			wantHashCalls: 0,
+			wantHash:      "sha256-cached-foo",
+			wantGoVersion: "1.22",
+		},
+		{
+			name:          "HashesWhenVersionDiffers",
+			downloads:     []ModuleDownload{fooDownload},
+			existingMods:  map[string]mod.ModuleConfig{"example.com/foo": {Path: "example.com/foo", Version: "v1.0.0", Hash: "sha256-old"}},
+			wantHashCalls: 1,
+		},
+		{
+			name:          "HashesNewModuleNotInExisting",
+			downloads:     []ModuleDownload{barDownload},
+			existingMods:  map[string]mod.ModuleConfig{"example.com/foo": fooExisting},
+			wantHashCalls: 1,
+		},
+		{
+			name:          "HashesAllWhenExistingModsIsNil",
+			downloads:     []ModuleDownload{fooDownload, barDownload},
+			existingMods:  nil,
+			wantHashCalls: 2,
+		},
+		{
+			name:          "ReusesBothWhenAllMatch",
+			downloads:     []ModuleDownload{fooDownload, barDownload},
+			existingMods:  map[string]mod.ModuleConfig{"example.com/foo": fooExisting, "example.com/bar": barExisting},
+			wantHashCalls: 0,
+			wantHash:      "sha256-cached-foo",
+			wantGoVersion: "1.22",
+		},
+		{
+			name:      "HashesWhenCachedHashIsEmpty",
+			downloads: []ModuleDownload{fooDownload},
+			existingMods: map[string]mod.ModuleConfig{"example.com/foo": {
+				Path: "example.com/foo", Version: "v1.2.3", Hash: "",
+			}},
+			wantHashCalls: 1,
+		},
+		{
+			name:      "NeverReusesLocalEntryEvenIfVersionMatches",
+			downloads: []ModuleDownload{fooDownload},
+			existingMods: map[string]mod.ModuleConfig{"example.com/foo": {
+				Path: "example.com/foo", Version: "v1.2.3", Hash: "sha256-local", Local: "./local/foo",
+			}},
+			wantHashCalls: 1,
+		},
+		{
+			name:      "ReusesRemoteReplaceEntryWhenReplacedPathMatches",
+			downloads: []ModuleDownload{{Path: "example.com/foo-fork", Version: "v1.2.3", Dir: "/cache/fork"}},
+			existingMods: map[string]mod.ModuleConfig{"example.com/foo": {
+				Path: "example.com/foo", Version: "v1.2.3",
+				Hash: "sha256-replace-cached", GoVersion: "1.22",
+				ReplacedPath: "example.com/foo-fork",
+			}},
+			wantHashCalls: 0,
+			wantHash:      "sha256-replace-cached",
+			wantGoVersion: "1.22",
+		},
+		{
+			// Cached entry has no GoVersion (e.g. schema 3 manifest). Hash is still
+			// reused, but GoVersion must be populated from the module's go.mod so the
+			// field is filled in on the next generation rather than staying empty.
+			name:      "PopulatesGoVersionFromGoModWhenCachedEntryHasNone",
+			downloads: []ModuleDownload{fooDownload},
+			existingMods: map[string]mod.ModuleConfig{"example.com/foo": {
+				Path: "example.com/foo", Version: "v1.2.3", Hash: "sha256-cached-foo",
+				// GoVersion deliberately absent, simulating a schema 3 manifest
+			}},
+			wantHashCalls: 0,
+			wantHash:      "sha256-cached-foo",
+			// fooDownload has no GoMod path, so GoVersion stays empty; a separate
+			// sub-case below uses testdata/module/go.mod to confirm the read path.
+		},
+		{
+			// Same as above but with a real go.mod path so GoVersion is actually read.
+			name: "PopulatesGoVersionFromGoModFileWhenCachedEntryHasNone",
+			downloads: []ModuleDownload{
+				{Path: "example.com/foo", Version: "v1.2.3", Dir: "/cache/foo", GoMod: "testdata/module/go.mod"},
+			},
+			existingMods: map[string]mod.ModuleConfig{"example.com/foo": {
+				Path: "example.com/foo", Version: "v1.2.3", Hash: "sha256-cached-foo",
+			}},
+			wantHashCalls: 0,
+			wantHash:      "sha256-cached-foo",
+			wantGoVersion: "1.26.0", // from testdata/module/go.mod
+		},
+		{
+			// The go.mod replace target changed (fork → fork2) since the manifest was
+			// cached. The download IS recognised as a replacement for example.com/foo
+			// (via explicit remoteRepls), but the cached ReplacedPath (foo-fork) no
+			// longer matches the new target (foo-fork2), so the hash must be recomputed.
+			name:      "HashesRemoteReplaceWhenReplacedPathChanged",
+			downloads: []ModuleDownload{{Path: "example.com/foo-fork2", Version: "v1.2.3", Dir: "/cache/fork2"}},
+			existingMods: map[string]mod.ModuleConfig{"example.com/foo": {
+				Path: "example.com/foo", Version: "v1.2.3",
+				Hash: "sha256-replace-cached", ReplacedPath: "example.com/foo-fork",
+			}},
+			remoteRepls: map[string]mod.Replacement{
+				"example.com/foo-fork2": {OldPath: "example.com/foo", NewPath: "example.com/foo-fork2"},
+			},
+			wantHashCalls: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hasher := &countingHasher{hash: "sha256-fresh"}
+			r := &Resolver{exec: &fakeExecutor{}, hasher: hasher}
+
+			remoteRepls := tt.remoteRepls
+			if remoteRepls == nil {
+				// Derive remoteRepls from existingMods for cases that don't need
+				// explicit control over the replacement mapping.
+				remoteRepls = make(map[string]mod.Replacement)
+				for _, entry := range tt.existingMods {
+					if entry.ReplacedPath != "" {
+						remoteRepls[entry.ReplacedPath] = mod.Replacement{
+							OldPath: entry.Path,
+							NewPath: entry.ReplacedPath,
+						}
+					}
+				}
+			}
+
+			deps, err := r.resolveRemoteModules(context.Background(), remoteRepls, tt.downloads, nil, tt.existingMods)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantHashCalls, hasher.count.Load(), "hasher call count")
+
+			if len(deps) > 0 {
+				if tt.wantHash != "" {
+					assert.Equal(t, tt.wantHash, deps[0].Hash, "deps[0].Hash")
+				}
+				if tt.wantGoVersion != "" {
+					assert.Equal(t, tt.wantGoVersion, deps[0].GoVersion, "deps[0].GoVersion")
+				}
+			}
+			// For multi-module cases, verify the second dep's cached values too.
+			if len(deps) > 1 && tt.existingMods != nil {
+				entry := tt.existingMods[deps[1].Path]
+				if entry.Hash != "" {
+					assert.Equal(t, entry.Hash, deps[1].Hash, "deps[1].Hash")
+				}
+				if entry.GoVersion != "" {
+					assert.Equal(t, entry.GoVersion, deps[1].GoVersion, "deps[1].GoVersion")
+				}
+			}
+		})
+	}
 }

--- a/internal/vendor/vendor.go
+++ b/internal/vendor/vendor.go
@@ -67,8 +67,8 @@ func WithIncludePlatforms(platforms []string) Option {
 // time. This keeps the vendor package free of process-execution concerns
 // and allows the orchestrator to be exercised against fake resolvers.
 type Resolver interface {
-	ResolveModule(ctx context.Context, goMod *mod.GoModFile, platforms []string) ([]mod.ModuleConfig, error)
-	ResolveWorkspace(ctx context.Context, goWork *mod.GoWorkFile, platforms []string) ([]mod.ModuleConfig, error)
+	ResolveModule(ctx context.Context, goMod *mod.GoModFile, platforms []string, existingMods map[string]mod.ModuleConfig) ([]mod.ModuleConfig, error)
+	ResolveWorkspace(ctx context.Context, goWork *mod.GoWorkFile, platforms []string, existingMods map[string]mod.ModuleConfig) ([]mod.ModuleConfig, error)
 }
 
 type Vendor struct {
@@ -162,6 +162,7 @@ func (v *Vendor) processSource(ctx context.Context, src dependencySource, displa
 
 	existingData, err := os.ReadFile(vendorPath)
 	extraPlatforms := v.opts.extraPlatforms
+	var existingMods map[string]mod.ModuleConfig
 
 	if os.IsNotExist(err) {
 		if v.opts.detectDrift {
@@ -180,10 +181,11 @@ func (v *Vendor) processSource(ctx context.Context, src dependencySource, displa
 		if len(extraPlatforms) == 0 {
 			extraPlatforms = existing.IncludePlatforms
 		}
+		existingMods = existing.Mod
 	}
 
 	platforms := append(mod.DefaultPlatforms(), extraPlatforms...)
-	deps, rawTools, excludes, err := v.resolveSource(ctx, src, platforms)
+	deps, rawTools, excludes, err := v.resolveSource(ctx, src, platforms, existingMods)
 	if err != nil {
 		return resultError(displayPath, err)
 	}
@@ -215,16 +217,16 @@ func (v *Vendor) processSource(ctx context.Context, src dependencySource, displa
 
 // resolveSource dispatches to the appropriate resolver based on the source
 // type and returns the raw inputs needed to build a manifest.
-func (v *Vendor) resolveSource(ctx context.Context, src dependencySource, platforms []string) (deps []mod.ModuleConfig, rawTools []string, excludes map[string][]string, err error) {
+func (v *Vendor) resolveSource(ctx context.Context, src dependencySource, platforms []string, existingMods map[string]mod.ModuleConfig) (deps []mod.ModuleConfig, rawTools []string, excludes map[string][]string, err error) {
 	switch s := src.(type) {
 	case *mod.GoModFile:
-		deps, err = v.resolver.ResolveModule(ctx, s, platforms)
+		deps, err = v.resolver.ResolveModule(ctx, s, platforms, existingMods)
 		rawTools = s.Tools
 		if len(s.Excludes) > 0 {
 			excludes = s.Excludes
 		}
 	case *mod.GoWorkFile:
-		deps, err = v.resolver.ResolveWorkspace(ctx, s, platforms)
+		deps, err = v.resolver.ResolveWorkspace(ctx, s, platforms, existingMods)
 		if err != nil {
 			return
 		}

--- a/internal/vendor/vendor_test.go
+++ b/internal/vendor/vendor_test.go
@@ -61,7 +61,7 @@ func TestVendor(t *testing.T) {
 			if len(tt.includePlatforms) > 0 {
 				platforms = append(platforms, tt.includePlatforms...)
 			}
-			deps, err := resolver.ResolveModule(context.Background(), goMod, platforms)
+			deps, err := resolver.ResolveModule(context.Background(), goMod, platforms, nil)
 			require.NoError(t, err)
 
 			var tool mod.ToolConfig
@@ -132,7 +132,7 @@ func TestVendorWorkspace(t *testing.T) {
 			if len(tt.includePlatforms) > 0 {
 				platforms = append(platforms, tt.includePlatforms...)
 			}
-			deps, err := resolver.ResolveWorkspace(context.Background(), goWork, platforms)
+			deps, err := resolver.ResolveWorkspace(context.Background(), goWork, platforms, nil)
 			require.NoError(t, err)
 
 			members, err := goWork.ParseMembers()
@@ -188,11 +188,11 @@ type fakeResolver struct {
 	deps []mod.ModuleConfig
 }
 
-func (f *fakeResolver) ResolveModule(_ context.Context, _ *mod.GoModFile, _ []string) ([]mod.ModuleConfig, error) {
+func (f *fakeResolver) ResolveModule(_ context.Context, _ *mod.GoModFile, _ []string, _ map[string]mod.ModuleConfig) ([]mod.ModuleConfig, error) {
 	return f.deps, nil
 }
 
-func (f *fakeResolver) ResolveWorkspace(_ context.Context, _ *mod.GoWorkFile, _ []string) ([]mod.ModuleConfig, error) {
+func (f *fakeResolver) ResolveWorkspace(_ context.Context, _ *mod.GoWorkFile, _ []string, _ map[string]mod.ModuleConfig) ([]mod.ModuleConfig, error) {
 	return f.deps, nil
 }
 


### PR DESCRIPTION
closes #538

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Module and workspace dependency resolution can reuse previously parsed module metadata to reduce redundant remote processing across runs.

* **Bug Fixes**
  * Hash and Go version reuse now occurs only when cached metadata matches the resolved module and any applicable remote replacement details; package info is refreshed when needed.
  * If cached Go version is missing, it is derived from the module’s `go.mod` when available.

* **Tests**
  * Added concurrency-safe hashing coverage and expanded scenarios validating reuse vs recomputation, including remote replacement and Go version backfilling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->