### PR TITLE
feat(govendor): add internal/modulestxt parser package

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,12 +3,14 @@ on:
   push:
     branches:
       - main
+      - govendor-resolution-performance
     paths:
       - "**.go"
       - "go.mod"
   pull_request:
     branches:
       - main
+      - govendor-resolution-performance
     paths:
       - "**.go"
       - "go.mod"

--- a/.github/workflows/nix-checks.yml
+++ b/.github/workflows/nix-checks.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - govendor-resolution-performance
     paths:
       - "flake.nix"
       - "flake.lock"
@@ -15,6 +16,7 @@ on:
   pull_request:
     branches:
       - main
+      - govendor-resolution-performance
     paths:
       - "flake.nix"
       - "flake.lock"

--- a/.github/workflows/nix-fmt.yml
+++ b/.github/workflows/nix-fmt.yml
@@ -3,11 +3,13 @@ on:
   push:
     branches:
       - main
+      - govendor-resolution-performance
     paths:
       - "**/*.nix"
   pull_request:
     branches:
       - main
+      - govendor-resolution-performance
     paths:
       - "**/*.nix"
 

--- a/.github/workflows/nix-packages.yml
+++ b/.github/workflows/nix-packages.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - govendor-resolution-performance
     paths:
       - "goscrape.nix"
       - "govendor.nix"
@@ -15,6 +16,7 @@ on:
   pull_request:
     branches:
       - main
+      - govendor-resolution-performance
     paths:
       - "goscrape.nix"
       - "govendor.nix"

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - govendor-resolution-performance
     paths-ignore:
       - "LICENSE"
       - ".github/stale.yml"
@@ -14,6 +15,7 @@ on:
   pull_request:
     branches:
       - main
+      - govendor-resolution-performance
     paths-ignore:
       - "LICENSE"
       - ".github/stale.yml"

--- a/internal/modulestxt/modulestxt.go
+++ b/internal/modulestxt/modulestxt.go
@@ -1,0 +1,145 @@
+// Package modulestxt parses the vendor/modules.txt format produced by
+// go mod vendor and go work vendor.
+package modulestxt
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// Module is one entry from a vendor/modules.txt file.
+type Module struct {
+	Path      string
+	Version   string
+	Explicit  bool
+	GoVersion string
+	Packages  []string
+	// nil when no replacement directive is present
+	Replace *Replace
+}
+
+// Replace holds the target of a replace directive. Exactly one of Path or
+// Local is non-empty: Path for remote replacements, Local for local ones.
+type Replace struct {
+	// replacement module path (remote replace only)
+	Path string
+	// replacement module version (remote replace only)
+	Version string
+	// relative filesystem path (local replace only)
+	Local string
+}
+
+// Parse reads a vendor/modules.txt file and returns the ordered list of
+// modules it describes. The workspace header (## workspace) is accepted and
+// ignored. Parse is tolerant of modules that have no package lines.
+func Parse(r io.Reader) ([]Module, error) {
+	var modules []Module
+	var current *Module
+
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		switch {
+		case line == "## workspace":
+			// workspace header — accepted, produces no output
+
+		case strings.HasPrefix(line, "# "):
+			if current != nil {
+				modules = append(modules, *current)
+			}
+			m, err := parseHeader(line[2:])
+			if err != nil {
+				return nil, err
+			}
+			current = &m
+
+		case strings.HasPrefix(line, "## "):
+			if current == nil {
+				return nil, fmt.Errorf("modulestxt: annotation before module header: %q", line)
+			}
+			parseAnnotation(line[3:], current)
+
+		case line != "":
+			if current != nil {
+				current.Packages = append(current.Packages, line)
+			}
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	if current != nil {
+		modules = append(modules, *current)
+	}
+	return modules, nil
+}
+
+// parseHeader parses the content after the leading "# " on a module header
+// line. Accepted forms:
+//
+//	path version
+//	path version => newpath newversion
+//	path version => ./dir
+//	path => ./dir
+func parseHeader(s string) (Module, error) {
+	left, right, hasReplace := strings.Cut(s, " => ")
+
+	parts := strings.Fields(left)
+	var m Module
+	switch len(parts) {
+	case 1:
+		// "path" — only valid in the wildcard local-replace form "path => ./dir"
+		if !hasReplace {
+			return Module{}, fmt.Errorf("modulestxt: missing version in header: %q", s)
+		}
+		m.Path = parts[0]
+	case 2:
+		m.Path = parts[0]
+		m.Version = parts[1]
+	default:
+		return Module{}, fmt.Errorf("modulestxt: malformed module header: %q", s)
+	}
+
+	if !hasReplace {
+		return m, nil
+	}
+
+	repl, err := parseReplace(right, s)
+	if err != nil {
+		return Module{}, err
+	}
+	m.Replace = &repl
+	return m, nil
+}
+
+func parseReplace(s, header string) (Replace, error) {
+	parts := strings.Fields(s)
+	switch {
+	case len(parts) == 1 && strings.HasPrefix(parts[0], "."):
+		return Replace{Local: parts[0]}, nil
+	case len(parts) == 2 && strings.HasPrefix(parts[0], "."):
+		// ./dir vX.Y — unusual but accepted; treat as local
+		return Replace{Local: parts[0]}, nil
+	case len(parts) == 2:
+		return Replace{Path: parts[0], Version: parts[1]}, nil
+	default:
+		return Replace{}, fmt.Errorf("modulestxt: malformed replacement in header: %q", header)
+	}
+}
+
+// parseAnnotation parses the content after "## " and updates the module in
+// place. Accepted forms: "explicit", "go X.Y", "explicit; go X.Y".
+func parseAnnotation(s string, m *Module) {
+	for part := range strings.SplitSeq(s, "; ") {
+		switch {
+		case part == "explicit":
+			m.Explicit = true
+		case strings.HasPrefix(part, "go "):
+			m.GoVersion = strings.TrimPrefix(part, "go ")
+		}
+	}
+}

--- a/internal/modulestxt/parse_test.go
+++ b/internal/modulestxt/parse_test.go
@@ -1,0 +1,185 @@
+package modulestxt_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/purpleclay/go-overlay/internal/modulestxt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func mustOpen(t *testing.T, path string) *os.File {
+	t.Helper()
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { f.Close() })
+	return f
+}
+
+func ptr[T any](v T) *T { return &v }
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name    string
+		fixture string
+		want    []modulestxt.Module
+	}{
+		{
+			name:    "SimpleModulesWithPackages",
+			fixture: "testdata/simple.txt",
+			want: []modulestxt.Module{
+				{
+					Path:      "charm.land/lipgloss/v2",
+					Version:   "v2.0.3",
+					Explicit:  true,
+					GoVersion: "1.25.0",
+					Packages:  []string{"charm.land/lipgloss/v2"},
+				},
+				{
+					Path:      "github.com/charmbracelet/colorprofile",
+					Version:   "v0.4.3",
+					Explicit:  true,
+					GoVersion: "1.25.0",
+					Packages:  []string{"github.com/charmbracelet/colorprofile"},
+				},
+				{
+					Path:      "github.com/charmbracelet/x/ansi",
+					Version:   "v0.11.7",
+					Explicit:  true,
+					GoVersion: "1.24.2",
+					Packages: []string{
+						"github.com/charmbracelet/x/ansi",
+						"github.com/charmbracelet/x/ansi/kitty",
+						"github.com/charmbracelet/x/ansi/parser",
+					},
+				},
+				{
+					Path:      "golang.org/x/sys",
+					Version:   "v0.44.0",
+					Explicit:  true,
+					GoVersion: "1.25.0",
+					Packages:  []string{"golang.org/x/sys/unix", "golang.org/x/sys/windows"},
+				},
+			},
+		},
+		{
+			name:    "RemoteReplacement",
+			fixture: "testdata/remote-replace.txt",
+			want: []modulestxt.Module{
+				{
+					Path:      "gopkg.in/ini.v1",
+					Version:   "v1.67.0",
+					Explicit:  true,
+					GoVersion: "1.14",
+					Packages:  []string{"gopkg.in/ini.v1"},
+					Replace:   ptr(modulestxt.Replace{Path: "github.com/go-ini/ini", Version: "v1.67.0"}),
+				},
+				{
+					Path:      "github.com/stretchr/testify",
+					Version:   "v1.11.1",
+					Explicit:  true,
+					GoVersion: "1.20",
+					Packages:  []string{"github.com/stretchr/testify"},
+				},
+			},
+		},
+		{
+			// Exercises the wildcard local-replace form: "# path => ./dir" (no version).
+			name:    "LocalReplacement",
+			fixture: "testdata/local-replace.txt",
+			want: []modulestxt.Module{
+				{
+					Path:      "github.com/go-overlay/examples/local-replaces/units",
+					Version:   "",
+					Explicit:  true,
+					GoVersion: "1.26.3",
+					Packages:  []string{"github.com/go-overlay/examples/local-replaces/units"},
+					Replace:   ptr(modulestxt.Replace{Local: "./units"}),
+				},
+			},
+		},
+		{
+			name:    "WorkspaceHeader",
+			fixture: "testdata/workspace.txt",
+			want: []modulestxt.Module{
+				{
+					Path:      "github.com/purpleclay/go-overlay/examples/go-workspace/mood",
+					Version:   "v0.0.0",
+					Explicit:  true,
+					GoVersion: "1.25.4",
+					Replace:   ptr(modulestxt.Replace{Local: "./mood"}),
+				},
+				{
+					Path:      "golang.org/x/text",
+					Version:   "v0.21.0",
+					Explicit:  true,
+					GoVersion: "1.23.0",
+					Packages:  []string{"golang.org/x/text/language"},
+				},
+			},
+		},
+		{
+			name:    "ModuleWithNoPackages",
+			fixture: "testdata/no-packages.txt",
+			want: []modulestxt.Module{
+				{
+					Path:      "github.com/foo/bar",
+					Version:   "v1.0.0",
+					Explicit:  true,
+					GoVersion: "1.21",
+				},
+				{
+					Path:      "github.com/foo/baz",
+					Version:   "v2.0.0",
+					Explicit:  true,
+					GoVersion: "1.22",
+					Packages:  []string{"github.com/foo/baz"},
+				},
+			},
+		},
+		{
+			name:    "GoVersionOnlyAnnotation",
+			fixture: "testdata/go-version-only.txt",
+			want: []modulestxt.Module{
+				{
+					Path:      "github.com/foo/explicit",
+					Version:   "v1.0.0",
+					Explicit:  true,
+					GoVersion: "1.21",
+					Packages:  []string{"github.com/foo/explicit"},
+				},
+				{
+					Path:      "github.com/foo/implicit",
+					Version:   "v1.0.0",
+					Explicit:  false,
+					GoVersion: "1.20",
+					Packages:  []string{"github.com/foo/implicit"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := mustOpen(t, tt.fixture)
+			got, err := modulestxt.Parse(f)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestParseEmpty(t *testing.T) {
+	got, err := modulestxt.Parse(strings.NewReader(""))
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestParseWorkspaceOnly(t *testing.T) {
+	// A workspace modules.txt with only the header and no modules (edge case).
+	got, err := modulestxt.Parse(strings.NewReader("## workspace\n"))
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}

--- a/internal/modulestxt/testdata/go-version-only.txt
+++ b/internal/modulestxt/testdata/go-version-only.txt
@@ -1,0 +1,6 @@
+# github.com/foo/explicit v1.0.0
+## explicit; go 1.21
+github.com/foo/explicit
+# github.com/foo/implicit v1.0.0
+## go 1.20
+github.com/foo/implicit

--- a/internal/modulestxt/testdata/local-replace.txt
+++ b/internal/modulestxt/testdata/local-replace.txt
@@ -1,0 +1,3 @@
+# github.com/go-overlay/examples/local-replaces/units => ./units
+## explicit; go 1.26.3
+github.com/go-overlay/examples/local-replaces/units

--- a/internal/modulestxt/testdata/no-packages.txt
+++ b/internal/modulestxt/testdata/no-packages.txt
@@ -1,0 +1,5 @@
+# github.com/foo/bar v1.0.0
+## explicit; go 1.21
+# github.com/foo/baz v2.0.0
+## explicit; go 1.22
+github.com/foo/baz

--- a/internal/modulestxt/testdata/remote-replace.txt
+++ b/internal/modulestxt/testdata/remote-replace.txt
@@ -1,0 +1,6 @@
+# gopkg.in/ini.v1 v1.67.0 => github.com/go-ini/ini v1.67.0
+## explicit; go 1.14
+gopkg.in/ini.v1
+# github.com/stretchr/testify v1.11.1
+## explicit; go 1.20
+github.com/stretchr/testify

--- a/internal/modulestxt/testdata/simple.txt
+++ b/internal/modulestxt/testdata/simple.txt
@@ -1,0 +1,15 @@
+# charm.land/lipgloss/v2 v2.0.3
+## explicit; go 1.25.0
+charm.land/lipgloss/v2
+# github.com/charmbracelet/colorprofile v0.4.3
+## explicit; go 1.25.0
+github.com/charmbracelet/colorprofile
+# github.com/charmbracelet/x/ansi v0.11.7
+## explicit; go 1.24.2
+github.com/charmbracelet/x/ansi
+github.com/charmbracelet/x/ansi/kitty
+github.com/charmbracelet/x/ansi/parser
+# golang.org/x/sys v0.44.0
+## explicit; go 1.25.0
+golang.org/x/sys/unix
+golang.org/x/sys/windows

--- a/internal/modulestxt/testdata/workspace.txt
+++ b/internal/modulestxt/testdata/workspace.txt
@@ -1,0 +1,6 @@
+## workspace
+# github.com/purpleclay/go-overlay/examples/go-workspace/mood v0.0.0 => ./mood
+## explicit; go 1.25.4
+# golang.org/x/text v0.21.0
+## explicit; go 1.23.0
+golang.org/x/text/language


### PR DESCRIPTION
closes #546

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for reading vendored module lists, including workspace files, package listings, and module replacement entries.
  * Improved handling of modules with no packages and Go version annotations.

* **Bug Fixes**
  * Added validation for malformed module and replacement entries, with clearer errors on invalid input.

* **Tests**
  * Added coverage for simple, workspace, local replacement, remote replacement, and no-package cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->