### PR TITLE
Escape tildes in Go package path in vendor env

### DIFF
--- a/builder/vendor-env.nix
+++ b/builder/vendor-env.nix
@@ -45,22 +45,28 @@
     ${concatMapStringsSep "\n" (
         goPackagePath: let
           modSrc = sources.${goPackagePath};
+
+          pkgPath = escapeShellArg goPackagePath;
         in
           if useSymlinks
           then ''
-            if [ -d "$out/${escapeShellArg goPackagePath}" ]; then
-                cp -rs --update=none ${modSrc}/* "$out/${escapeShellArg goPackagePath}/"
+            pkg_path=${pkgPath}
+
+            if [ -d "$out/$pkg_path" ]; then
+                cp -rs --update=none ${modSrc}/* "$out/$pkg_path/"
             else
-                mkdir -p "$out/$(dirname ${escapeShellArg goPackagePath})"
-                ln -s ${modSrc} "$out/${escapeShellArg goPackagePath}"
+                mkdir -p "$out/$(dirname "$pkg_path")"
+                ln -s ${modSrc} "$out/$pkg_path"
             fi
           ''
           else ''
-            if [ -d "$out/${escapeShellArg goPackagePath}" ]; then
-                cp -r --reflink=auto --update=none ${modSrc}/* "$out/${escapeShellArg goPackagePath}/"
+            pkg_path=${pkgPath}
+
+            if [ -d "$out/$pkg_path" ]; then
+                cp -r --reflink=auto --update=none ${modSrc}/* "$out/$pkg_path/"
             else
-                mkdir -p "$out/$(dirname ${escapeShellArg goPackagePath})"
-                cp -r --reflink=auto ${modSrc} "$out/${escapeShellArg goPackagePath}"
+                mkdir -p "$out/$(dirname "$pkg_path")"
+                cp -r --reflink=auto ${modSrc} "$out/$pkg_path"
             fi
           ''
       )

--- a/test/default.nix
+++ b/test/default.nix
@@ -356,4 +356,52 @@ in {
       };
   in
     assertHostToolDrvPathStable "hostTool-workspace-drvpath-stable-across-unrelated-changes" mkDrv baseSrc touchedSrc;
+
+  mkModuleCopyCommands-works-with-tildes-symlink = let
+    inherit (import ../builder/vendor-env.nix {inherit (pkgs) lib runCommand fetchGoModule;}) mkModuleCopyCommands;
+
+    sources = {
+      "git.sr.ht/~sbinet/gg" = ./fixtures/mkModuleCopyCommands-module;
+    };
+  in
+    pkgs.runCommand "test-mkModuleCopyCommands-works-with-tildes-symlink" {} (
+      ''
+        mkdir -p $out
+      ''
+      + mkModuleCopyCommands {
+        inherit sources;
+        useSymlinks = true;
+      }
+      + ''
+        if [ ! -L "$out/git.sr.ht/~sbinet/gg" ]; then
+          echo "Test 'mkModuleCopyCommands-works-with-tildes-symlink' failed: git.sr.ht/~sbinet/gg not found in $out"
+
+          exit 1
+        fi
+      ''
+    );
+
+  mkModuleCopyCommands-works-with-tildes-copy = let
+    inherit (import ../builder/vendor-env.nix {inherit (pkgs) lib runCommand fetchGoModule;}) mkModuleCopyCommands;
+
+    sources = {
+      "git.sr.ht/~sbinet/gg" = ./fixtures/mkModuleCopyCommands-module;
+    };
+  in
+    pkgs.runCommand "test-mkModuleCopyCommands-works-with-tildes-copy" {} (
+      ''
+        mkdir -p $out
+      ''
+      + mkModuleCopyCommands {
+        inherit sources;
+        useSymlinks = false;
+      }
+      + ''
+        if [ ! -d "$out/git.sr.ht/~sbinet/gg" ]; then
+          echo "Test 'mkModuleCopyCommands-works-with-tildes-copy' failed: git.sr.ht/~sbinet/gg not found in $out"
+
+          exit 1
+        fi
+      ''
+    );
 }

--- a/test/fixtures/mkModuleCopyCommands-module/go.mod
+++ b/test/fixtures/mkModuleCopyCommands-module/go.mod
@@ -1,0 +1,3 @@
+module github.com/purpleclay/go-overlay/test/fixtures/mkModuleCopyCommands-module
+
+go 1.26.3


### PR DESCRIPTION
Closes #565

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of module source paths containing `~` and other special characters during environment setup.
  * Strengthened shell quoting by reusing a single escaped module path value, improving correctness for both symlink and non-symlink copy modes.
* **Tests**
  * Added runtime coverage for module keys containing `~`, validating expected outputs in both symlink and copy configurations.
* **Chores**
  * Added a Go module fixture used by the new test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->