### PR TITLE
feat(goscrape): exclude prereleases by default from mod-proxy detect

### DIFF
--- a/.github/workflows/tools-update.yml
+++ b/.github/workflows/tools-update.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Detect Latest Version
         id: detect
         run: |
-          version=$(nix run .#goscrape -- mod-proxy detect ${{ matrix.tool.module }})
+          version=$(nix run .#goscrape -- mod-proxy detect ${{ matrix.tool.module }} --include-prerelease)
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Check and Generate Manifest

--- a/goscrape.nix
+++ b/goscrape.nix
@@ -5,8 +5,8 @@
   commit ? "unknown",
 }: let
   pname = "goscrape";
-  version = "v0.3.0";
-  buildDate = "2026-03-25T00:00:00Z";
+  version = "v0.4.0";
+  buildDate = "2026-08-05T00:00:00Z";
 in
   buildGoApplication {
     inherit pname version go;

--- a/internal/cli/goscrape/godev/detect.go
+++ b/internal/cli/goscrape/godev/detect.go
@@ -99,9 +99,9 @@ func newDetectCmd() *cobra.Command {
 		Short: "Detect the latest Go release or list all available versions",
 		Long: `
 		Scrapes the Golang website (https://go.dev/dl/) to detect Go versions.
-		By default, returns the latest version. Use --all to list all available
-		versions. Optionally provide a version prefix to filter results to a
-		specific release line.
+		By default, returns the latest stable version, excluding prereleases.
+		Use --all to list all available versions. Optionally provide a version
+		prefix to filter results to a specific release line.
 		`,
 		Example: `
 		# Detect the latest Go version

--- a/internal/cli/goscrape/modproxy/detect.go
+++ b/internal/cli/goscrape/modproxy/detect.go
@@ -10,8 +10,9 @@ import (
 
 func newDetectCmd() *cobra.Command {
 	var (
-		prefix string
-		all    bool
+		prefix            string
+		all               bool
+		includePrerelease bool
 	)
 
 	cmd := &cobra.Command{
@@ -19,13 +20,16 @@ func newDetectCmd() *cobra.Command {
 		Short: "Detect the latest version of a Go module from the module proxy",
 		Long: `
 		Queries the Go module proxy (https://proxy.golang.org) and detects versions
-		of the given module. By default, returns the latest semver-tagged version.
-		Use --all to list all available versions. An optional prefix flag can restrict
-		results to a specific version line.
+		of the given module. By default, returns the latest semver-tagged version,
+		excluding prereleases. Use --all to list all available versions. An optional
+		prefix flag can restrict results to a specific version line.
 		`,
 		Example: `
 		# Detect the latest version of govulncheck
 		goscrape mod-proxy detect golang.org/x/vuln
+
+		# Detect the latest version, including prereleases
+		goscrape mod-proxy detect golang.org/x/vuln --include-prerelease
 
 		# Detect the latest 1.0.x version
 		goscrape mod-proxy detect golang.org/x/vuln --prefix 1.0
@@ -52,6 +56,10 @@ func newDetectCmd() *cobra.Command {
 				return nil
 			}
 
+			if !includePrerelease {
+				versions = version.ExcludePrerelease(versions)
+			}
+
 			latest, err := version.Latest(versions, args[0])
 			if err != nil {
 				return err
@@ -64,5 +72,7 @@ func newDetectCmd() *cobra.Command {
 
 	cmd.Flags().StringVarP(&prefix, "prefix", "p", "", "filter versions by prefix (e.g. 1.1)")
 	cmd.Flags().BoolVar(&all, "all", false, "list all available versions instead of just the latest")
+	cmd.Flags().BoolVar(&includePrerelease, "include-prerelease", false,
+		"include prerelease versions when detecting the latest version")
 	return cmd
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -3,6 +3,8 @@ package version
 import (
 	"fmt"
 	"strings"
+
+	"golang.org/x/mod/semver"
 )
 
 // Latest returns the last element from a sorted list of versions, which is
@@ -12,6 +14,18 @@ func Latest(versions []string, module string) (string, error) {
 		return "", fmt.Errorf("no versions found for module %s", module)
 	}
 	return versions[len(versions)-1], nil
+}
+
+// ExcludePrerelease returns versions with a semver prerelease component
+// (e.g. v1.1.0-rc1) filtered out.
+func ExcludePrerelease(versions []string) []string {
+	result := make([]string, 0, len(versions))
+	for _, v := range versions {
+		if semver.Prerelease(v) == "" {
+			result = append(result, v)
+		}
+	}
+	return result
 }
 
 // TrimGlob reports whether pattern ends with a wildcard (*) and returns the

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -20,6 +20,20 @@ func TestLatestNoVersions(t *testing.T) {
 	require.EqualError(t, err, "no versions found for module golang.org/x/vuln")
 }
 
+func TestExcludePrerelease(t *testing.T) {
+	versions := []string{"v1.0.0", "v1.1.0-rc1", "v1.1.0", "v2.0.0-beta.1"}
+
+	got := ExcludePrerelease(versions)
+	assert.Equal(t, []string{"v1.0.0", "v1.1.0"}, got)
+}
+
+func TestExcludePrereleaseNoPrereleases(t *testing.T) {
+	versions := []string{"v1.0.0", "v1.1.0"}
+
+	got := ExcludePrerelease(versions)
+	assert.Equal(t, versions, got)
+}
+
 func TestTrimGlob(t *testing.T) {
 	prefix, ok := TrimGlob("v1.1*")
 	assert.True(t, ok)


### PR DESCRIPTION
closes #570

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an option to include prerelease versions when using module proxy detection.
  - Detection now selects the latest stable release by default, while prefixes can filter results to a release line.
  - The `--all` option continues to display every available version.
  - Automated version checks now include prerelease versions when configured.

- **Documentation**
  - Updated command descriptions, help text, and examples to clarify release behavior.

- **Chores**
  - Updated the application version to v0.4.0 and refreshed the build date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->