### PR TITLE
fix(scrape): stop GoVersion truncating beta versions into their stable release

### DIFF
--- a/goscrape.nix
+++ b/goscrape.nix
@@ -5,8 +5,8 @@
   commit ? "unknown",
 }: let
   pname = "goscrape";
-  version = "v0.4.1";
-  buildDate = "2026-08-06T00:00:00Z";
+  version = "v0.4.2";
+  buildDate = "2026-08-07T00:00:00Z";
 in
   buildGoApplication {
     inherit pname version go;

--- a/internal/cli/goscrape/godev/detect_test.go
+++ b/internal/cli/goscrape/godev/detect_test.go
@@ -80,6 +80,20 @@ func TestListVersions(t *testing.T) {
 	assert.NotEmpty(t, versions)
 }
 
+func TestListVersionsDistinguishesBetaFromStable(t *testing.T) {
+	fd, err := os.ReadFile("testdata/index-20260806.html")
+	require.NoError(t, err)
+
+	// go1.19beta1 predates the current stable go1.19 release line. Both must
+	// be listed as their own distinct versions rather than merging into a
+	// single "1.19" entry.
+	versions, err := listVersions(string(fd), "1.19")
+	require.NoError(t, err)
+
+	assert.Contains(t, versions, "1.19beta1")
+	assert.Contains(t, versions, "1.19")
+}
+
 func TestListVersionsWithPrefix1_25(t *testing.T) {
 	fd, err := os.ReadFile("testdata/index-20260215.html")
 	require.NoError(t, err)

--- a/internal/scrape/parse.go
+++ b/internal/scrape/parse.go
@@ -7,14 +7,25 @@ import (
 	"github.com/purpleclay/chomp"
 )
 
+// prereleaseTag matches an optional "rc" or "beta" pre-release suffix
+// followed by its number (e.g. "rc1", "beta2"). Matched as a literal token
+// rather than folding its letters into a character class, since a class
+// containing 'a' would also match the start of "aix" - a real target OS
+// name that immediately follows the version in scraped download links
+// (e.g. "go1.21.4.aix-ppc64.tar.gz").
+var prereleaseTag = chomp.Opt(chomp.Recognize(chomp.Pair(
+	chomp.First(chomp.Tag("rc"), chomp.Tag("beta")),
+	chomp.Any("1234567890"),
+)))
+
 func GoVersion() chomp.Combinator[string] {
 	return func(s string) (string, string, error) {
-		rem, rel, err := chomp.All(chomp.Tag("go"), chomp.Any(".1234567890rc"))(s)
+		rem, rel, err := chomp.All(chomp.Tag("go"), chomp.Any(".1234567890"), prereleaseTag)(s)
 		if err != nil {
 			return rem, "", err
 		}
 
-		return rem, strings.TrimSuffix(rel[1], "."), nil
+		return rem, strings.TrimSuffix(rel[1]+rel[2], "."), nil
 	}
 }
 
@@ -41,9 +52,15 @@ func Href(version string) chomp.Combinator[string] {
 			normalizedVersion = "go" + normalizedVersion
 		}
 
+		// An exact rc/beta version (e.g. "go1.19beta1") or a full patch
+		// version (e.g. "go1.21.4") needs a trailing "." to avoid matching a
+		// longer version that shares the same prefix (go1.19beta1 would
+		// otherwise also match go1.19beta10, and go1.21.4 would match
+		// go1.21.40). A bare minor prefix (e.g. "go1.19") must not get one,
+		// since listVersions relies on matching every version under it.
+		isExactPrerelease := strings.Contains(normalizedVersion, "rc") || strings.Contains(normalizedVersion, "beta")
 		hrefVersion := normalizedVersion
-		if !strings.Contains(normalizedVersion, "rc") && !strings.Contains(normalizedVersion, "beta") &&
-			strings.Count(normalizedVersion, ".") >= 2 {
+		if isExactPrerelease || strings.Count(normalizedVersion, ".") >= 2 {
 			hrefVersion = normalizedVersion + "."
 		}
 

--- a/internal/scrape/parse_test.go
+++ b/internal/scrape/parse_test.go
@@ -30,6 +30,24 @@ func TestGoVersionCombinator(t *testing.T) {
 			input:    "go1.25rc1",
 			expected: "1.25rc1",
 		},
+		{
+			name:     "Beta",
+			input:    "go1.19beta1",
+			expected: "1.19beta1",
+		},
+		{
+			name:     "BetaWithDownloadFilename",
+			input:    "go1.19beta1.linux-amd64.tar.gz",
+			expected: "1.19beta1",
+		},
+		{
+			// Regression guard: AIX is a real, currently-supported target
+			// whose name starts with 'a'. Any fix for beta parsing must not
+			// widen the character class in a way that eats into it.
+			name:     "PatchVersionWithAIXTarget",
+			input:    "go1.21.4.aix-ppc64.tar.gz",
+			expected: "1.21.4",
+		},
 	}
 
 	for _, tt := range tests {
@@ -68,6 +86,51 @@ Download
 	_, result, err := Href("1.21.4")(html)
 	require.NoError(t, err)
 	require.Equal(t, "/dl/go1.21.4.linux-amd64.tar.gz", result)
+}
+
+func TestHrefCombinatorMatchesBetaExactly(t *testing.T) {
+	html := `<div>
+<a class="download" href="/dl/go1.19beta1.linux-amd64.tar.gz">
+Download
+</a>
+</div>`
+
+	_, result, err := Href("1.19beta1")(html)
+	require.NoError(t, err)
+	require.Equal(t, "/dl/go1.19beta1.linux-amd64.tar.gz", result)
+}
+
+func TestHrefCombinatorDoesNotMatchBetaTenWhenRequestingBetaOne(t *testing.T) {
+	// beta1 is a string-prefix of beta10, so a naive prefix match on
+	// "go1.19beta1" would incorrectly match the beta10 entry if it appears
+	// first on the page.
+	html := `<div>
+<a class="download" href="/dl/go1.19beta10.linux-amd64.tar.gz">
+Download
+</a>
+<a class="download" href="/dl/go1.19beta1.linux-amd64.tar.gz">
+Download
+</a>
+</div>`
+
+	_, result, err := Href("1.19beta1")(html)
+	require.NoError(t, err)
+	require.Equal(t, "/dl/go1.19beta1.linux-amd64.tar.gz", result)
+}
+
+func TestHrefCombinatorDoesNotMatchRcTenWhenRequestingRcOne(t *testing.T) {
+	html := `<div>
+<a class="download" href="/dl/go1.25rc10.linux-amd64.tar.gz">
+Download
+</a>
+<a class="download" href="/dl/go1.25rc1.linux-amd64.tar.gz">
+Download
+</a>
+</div>`
+
+	_, result, err := Href("1.25rc1")(html)
+	require.NoError(t, err)
+	require.Equal(t, "/dl/go1.25rc1.linux-amd64.tar.gz", result)
 }
 
 func TestHrefCombinatorVersionMissing(t *testing.T) {


### PR DESCRIPTION
closes #574

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of Go beta and release-candidate versions.
  * Fixed version parsing for download filenames targeting AIX.
  * Ensured beta and stable releases remain distinct when filtering versions.
  * Improved matching of beta and release-candidate download links to prevent incorrect results.
  * Prevented shorter prerelease versions from matching longer versions such as beta10 or rc10.

* **Chores**
  * Updated the package release to version 0.4.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->